### PR TITLE
Fix webpack entry point after rabbithole rename

### DIFF
--- a/src/build_logic/webpack.justinholmes.common.js
+++ b/src/build_logic/webpack.justinholmes.common.js
@@ -96,7 +96,7 @@ export default {
         strike_set_stone: `${frontendJSDir}/strike_set_stones.js`,
         add_show_for_stone_minting: `${frontendJSDir}/add_show_for_stone_minting.js`,
         oracle_client: `${frontendJSDir}/oracle_client.js`,
-        chartifact_player: `${frontendJSDir}/chartifact_player.js`,
+        chartifact_player: `${frontendJSDir}/rabbithole_player.js`,
         chartifacts_embed: `${frontendJSDir}/chartifacts-embed.js`,
     },
     module: {


### PR DESCRIPTION
## Problem
PR #305 renamed `chartifact_player.js` → `rabbithole_player.js` but didn't update the webpack entry point, causing build failures:
```
ERROR in chartifact_player
Module not found: Error: Can't resolve 'chartifact_player.js'
```

## Solution
Update webpack entry point to reference the correct filename.

## Note
This is a temporary fix that keeps the entry point name as `chartifact_player` while pointing to `rabbithole_player.js`. 

**TODO**: Rename the entry point itself from 'chartifact_player' to 'rabbithole_player' for consistency (requires updating HTML templates that reference it).