### PR TITLE
Add rsync deployment to NearlyFreeSpeech after production builds

### DIFF
--- a/integration/Jenkinsfile
+++ b/integration/Jenkinsfile
@@ -217,6 +217,16 @@ pipeline {
                         sh """
                             rsync -av output/dist/* ${PR_BUILDS_DIR}/production
                         """
+
+                        // Deploy to production hosting (NearlyFreeSpeech)
+                        echo "Deploying to production hosting..."
+                        sh """
+                            rsync -vah --progress --delete \
+                                -e "ssh -i /var/jenkins_home/.ssh/id_ed25519_nfs -o StrictHostKeyChecking=no" \
+                                ${PR_BUILDS_DIR}/production/* \
+                                jmyles_justinholmescom@ssh.nyc1.nearlyfreespeech.net:
+                        """
+                        echo "Production deployment complete"
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Replaces the cronjob-based rsync with in-pipeline deployment. After successful production builds, automatically rsyncs to the production hosting server.

## Changes
- Added rsync step to Deploy stage for production builds
- Uses SSH key at `/var/jenkins_home/.ssh/id_ed25519_nfs`
- Syncs to `jmyles_justinholmescom@ssh.nyc1.nearlyfreespeech.net`

## Prerequisites
Requires `jenkins_nfs_ssh_key` to be deployed via maybelle-config ansible (already done).

## Benefits
- Full visibility of deployment in Jenkins UI
- Logs retained per build
- Automatic triggering after successful builds
- Can remove the cronjob once this is working