### PR TITLE
Add tmux-based collaborative dev server workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev:cg": "SKIP_CHAIN_DATA=true NODE_ENV=development webpack serve --config src/build_logic/webpack.cryptograss.dev.js",
     "dev:jh:signals": "node src/build_logic/dev-server-with-signals.js jh",
     "dev:cg:signals": "node src/build_logic/dev-server-with-signals.js cg",
+    "dev:jh:tmux": "node src/build_logic/dev-server-tmux.js jh",
+    "dev:cg:tmux": "node src/build_logic/dev-server-tmux.js cg",
     "restart-server": "node src/build_logic/restart-dev-server.js",
     "seed-dice": "node src/build_logic/seed_phrase_dice.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",

--- a/src/build_logic/dev-server-tmux.js
+++ b/src/build_logic/dev-server-tmux.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Launch dev server in tmux session
+ * Runs on port 4000 (shared space) for collaborative development
+ */
+
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+
+// Configuration
+const SITE_ARG = process.argv[2]; // 'jh' or 'cg'
+const SESSION_NAME = 'dev-server';
+const WORKSPACE_DIR = '/home/magent/workspace/arthel';
+const LOG_FILE = resolve('dev-server.log');
+
+if (!SITE_ARG || !['jh', 'cg'].includes(SITE_ARG)) {
+    console.error('Usage: node dev-server-tmux.js [jh|cg]');
+    process.exit(1);
+}
+
+const DEV_COMMAND = `SKIP_CHAIN_DATA=true NODE_ENV=development webpack serve --port 4000 --config src/build_logic/webpack.${SITE_ARG === 'jh' ? 'justinholmes' : 'cryptograss'}.dev.js`;
+
+function startServer() {
+    console.log(`🚀 Starting ${SITE_ARG.toUpperCase()} dev server in tmux...`);
+
+    // Check if session already exists
+    try {
+        execSync(`tmux has-session -t ${SESSION_NAME} 2>/dev/null`);
+        console.log(`✓ Dev server session '${SESSION_NAME}' already running`);
+        console.log(`  Attach with: tmux attach -t ${SESSION_NAME}`);
+        return;
+    } catch (e) {
+        // Session doesn't exist, create it
+    }
+
+    // Create new detached tmux session with a shell, then run the command
+    // This keeps the session alive after the server stops
+    const tmuxCommand = `tmux new-session -d -s ${SESSION_NAME} -c ${WORKSPACE_DIR}`;
+
+    execSync(tmuxCommand);
+
+    // Send the dev server command to the session
+    const startCommand = `tmux send-keys -t ${SESSION_NAME}:0.0 "${DEV_COMMAND} 2>&1 | tee ${LOG_FILE}" Enter`;
+
+    try {
+        execSync(startCommand);
+        console.log('✓ Dev server started in background on port 4000');
+        console.log(`  Attach with: tmux attach -t ${SESSION_NAME}`);
+        console.log(`  View logs: tail -f ${LOG_FILE}`);
+        console.log(`  Restart with: npm run restart-server`);
+    } catch (error) {
+        console.error('❌ Failed to start tmux session:', error.message);
+        process.exit(1);
+    }
+}
+
+// Start the server
+startServer();

--- a/src/build_logic/restart-dev-server.js
+++ b/src/build_logic/restart-dev-server.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * Restart dev server by joining tmux session, stopping it, and starting fresh
+ */
+
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+
+const SESSION_NAME = 'dev-server';
+const LOG_FILE = resolve('dev-server.log');
+
+console.log('🔄 Restarting dev server...');
+
+try {
+    // Check if session exists
+    execSync(`tmux has-session -t ${SESSION_NAME} 2>/dev/null`);
+
+    // Send Ctrl-C to stop the server (using session:window.pane format)
+    console.log('🛑 Stopping current server...');
+    execSync(`tmux send-keys -t ${SESSION_NAME}:0.0 C-c`);
+
+    // Wait a moment for cleanup
+    execSync('sleep 2');
+
+    // Send command to restart (up arrow to get last command, then enter)
+    console.log('🚀 Starting server...');
+    execSync(`tmux send-keys -t ${SESSION_NAME}:0.0 Up Enter`);
+
+    console.log('✅ Server restarted');
+    console.log(`  Attach with: tmux attach -t ${SESSION_NAME}`);
+    console.log(`  View logs: tail -f ${LOG_FILE}`);
+
+} catch (error) {
+    console.error('❌ No dev server session found');
+    console.error('   Start one with: npm run dev:jh:tmux');
+    process.exit(1);
+}


### PR DESCRIPTION
Introduces a new development workflow using tmux sessions for better team collaboration and visibility.

## New commands
- `npm run dev:jh:tmux` - Start justinholmes.com dev server in tmux
- `npm run dev:cg:tmux` - Start cryptograss.live dev server in tmux
- `npm run restart-server` - Restart server without killing session

## Features
- Server runs on port 4000 (shared collaborative space)
- Tmux session persists after server stops
- Multiple team members can attach and watch server restarts live
- Logs written to dev-server.log via tee

## Workflow
1. Start: `npm run dev:jh:tmux`
2. Watch: `tmux attach -t dev-server`
3. Restart externally: `npm run restart-server`
4. Stop within session: Ctrl-C (stays at prompt)
5. Detach without killing: Ctrl-B then D