### PR TITLE
Add rabbithole-player to chartifact_player chunk assignment

### DIFF
--- a/src/build_logic/webpack.justinholmes.common.js
+++ b/src/build_logic/webpack.justinholmes.common.js
@@ -34,7 +34,7 @@ const htmlPluginInstances = templateFiles.map(templatePath => {
         var chunks = ['main', 'add_show_for_stone_minting'];
     } else if (relativePath.startsWith('cryptograss/tools/oracle-of-bluegrass-bacon')) {
         var chunks = ['main', 'oracle_client'];
-    } else if (relativePath.startsWith('songs/') || relativePath.startsWith('songs/')) {
+    } else if (relativePath.startsWith('songs/') || relativePath.startsWith('rabbithole-player')) {
         var chunks = ['main', 'chartifact_player'];
     } else {
         var chunks = ['main'];


### PR DESCRIPTION
The rabbithole-player page needs the chartifact_player JS bundle but was falling through to the default 'main' only assignment, causing the page to be stuck on 'Loading player...'