### PR TITLE
Standardize JS output to [name].js for dev/prod consistency

### DIFF
--- a/src/build_logic/webpack.justinholmes.common.js
+++ b/src/build_logic/webpack.justinholmes.common.js
@@ -51,7 +51,10 @@ const htmlPluginInstances = templateFiles.map(templatePath => {
 const frontendJSDir = path.resolve(siteDir, 'js');
 
 export default {
-    output: { path: outputDistDir },
+    output: {
+        path: outputDistDir,
+        filename: '[name].js'
+    },
     plugins: [
         new CopyPlugin({
             patterns: [

--- a/src/build_logic/webpack.prod.js
+++ b/src/build_logic/webpack.prod.js
@@ -82,10 +82,7 @@ export async function generateProductionConfig() {
                     });
                 },
             },
-        ], output: {
-            filename: '[name].js',
-            path: outputDistDir,
-        }
+        ]
     });
 }
 


### PR DESCRIPTION
Fixes 404 error on production rabbithole-player - template expects /chartifact_player.js but prod was outputting /chartifact_player.bundle.js