### PR TITLE
Remove node-fetch import, use native fetch

### DIFF
--- a/src/build_logic/discord_video_fetcher.js
+++ b/src/build_logic/discord_video_fetcher.js
@@ -2,7 +2,7 @@ import { Client, GatewayIntentBits } from 'discord.js';
 import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
-import fetch from 'node-fetch';
+// Native fetch available in Node 18+
 import { getProjectDirs, initProjectDirs } from './locations.js';
 import { blueRailroadContractAddress } from './constants.js';
 


### PR DESCRIPTION
## Summary
- Removes `node-fetch` import from `discord_video_fetcher.js`
- Uses native `fetch` available in Node 18+
- Fixes Jenkins production build failure: "Cannot find package 'node-fetch'"

## Test plan
- [ ] Jenkins production build succeeds