### PR TITLE
Fix native fetch compatibility in video downloader tests

### DIFF
--- a/__tests__/video_downloader_tests.js
+++ b/__tests__/video_downloader_tests.js
@@ -7,17 +7,17 @@ const mockFs = {
 };
 
 const mockFetch = jest.fn(() => Promise.resolve({
-    buffer: () => Promise.resolve(Buffer.from('video data'))
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(10))
 }));
+
+// Mock global fetch (native fetch in Node 18+)
+globalThis.fetch = mockFetch;
 
 // Set up all mocks BEFORE any imports
 jest.unstable_mockModule('fs', () => ({
     default: mockFs,
     __esModule: true
-}));
-
-jest.unstable_mockModule('node-fetch', () => ({
-    default: mockFetch
 }));
 
 // Import the function we want to test

--- a/src/build_logic/discord_video_fetcher.js
+++ b/src/build_logic/discord_video_fetcher.js
@@ -22,8 +22,8 @@ function parseDiscordUrl(url) {
 
 async function downloadVideo(videoUrl, outputPath) {
     const response = await fetch(videoUrl);
-    const buffer = await response.buffer();
-    fs.writeFileSync(outputPath, buffer);
+    const arrayBuffer = await response.arrayBuffer();
+    fs.writeFileSync(outputPath, Buffer.from(arrayBuffer));
 }
 
 export async function downloadVideos(metadataList, outputDir) {


### PR DESCRIPTION
## Summary
- Use `arrayBuffer()` instead of `buffer()` in discord_video_fetcher.js (native fetch API)
- Update test to mock `globalThis.fetch` instead of `node-fetch` module
- Fixes Jenkins build failure after node-fetch removal in PR #331

The previous PR removed the node-fetch import but the code still called `response.buffer()` which is a node-fetch method. Native fetch uses `arrayBuffer()`.