### PR TITLE
Replace direct NFS deploy with marker-based system

### DIFF
--- a/integration/Jenkinsfile
+++ b/integration/Jenkinsfile
@@ -215,7 +215,9 @@ pipeline {
                         }
 
                     } else {
-                        // Production build
+                        // Production build - copy to staging area and create deploy marker
+                        // Actual deployment to NFS is handled by root cron on maybelle host
+                        // This separation prevents Jenkins compromise from directly pushing to production
 
                         echo "Production build for ${COMMIT_SHA}"
                         sh "mkdir -p ${PR_BUILDS_DIR}/production"
@@ -223,15 +225,12 @@ pipeline {
                             rsync -av output/dist/* ${PR_BUILDS_DIR}/production
                         """
 
-                        // Deploy to production hosting (NearlyFreeSpeech)
-                        echo "Deploying to production hosting..."
+                        // Create deploy marker for root cron to pick up
+                        echo "Creating deploy marker for production..."
                         sh """
-                            rsync -vah --progress --delete \
-                                -e "ssh -i /var/jenkins_home/.ssh/id_ed25519_nfs -o StrictHostKeyChecking=no" \
-                                ${PR_BUILDS_DIR}/production/* \
-                                jmyles_justinholmescom@ssh.nyc1.nearlyfreespeech.net:
+                            echo "commit=${COMMIT_SHA} build=${BUILD_NUMBER} time=\$(date -Iseconds)" > ${PR_BUILDS_DIR}/production/.deploy-ready
                         """
-                        echo "Production deployment complete"
+                        echo "Production build staged - deploy marker created"
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Security improvement: Jenkins no longer pushes directly to NearlyFreeSpeech.

**Before:** Jenkins rsynced directly to `jmyles_justinholmescom@ssh.nyc1.nearlyfreespeech.net`
**After:** Jenkins creates `.deploy-ready` marker; root cron on maybelle does the rsync

## Changes
- Removed direct rsync to NFS from production deploy stage
- Added marker file creation with build metadata (commit, build number, timestamp)
- Added comments explaining the security rationale

## Security Benefit
A compromised Jenkins can stage malicious builds but cannot push them to production. An attacker would also need root access on maybelle to complete the deployment.

## Deployment Order
1. Merge cryptograss/maybelle-config PR #15 first (adds the deploy script and cron)
2. Redeploy maybelle
3. Then merge this PR

If merged in wrong order, production builds will stage but not deploy until maybelle is updated.

## Also Includes
- Fix for native fetch compatibility (from PR #332) - uses `arrayBuffer()` instead of `buffer()`