### PR TITLE
Enable Blue Railroad V2 in chain data fetch

### DIFF
--- a/src/abi/blueRailroadV2ABI.js
+++ b/src/abi/blueRailroadV2ABI.js
@@ -1,4 +1,4 @@
-// BlueRailroadTrainV2 ABI - deployed on Optimism at 0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1
+// BlueRailroadTrainV2 ABI - deployed on Optimism at 0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7
 export const blueRailroadV2ABI = [
   // V2-specific view functions
   {

--- a/src/build_logic/blue_railroad.js
+++ b/src/build_logic/blue_railroad.js
@@ -57,8 +57,8 @@ export async function verifyBlueRailroadVideos() {
         );
     }
 
-    // Sort by latest first.
-    return Object.entries(metadata).reverse()
+    // Return the metadata object (keeping original structure)
+    return metadata;
 }
 
 /**

--- a/src/build_logic/chain_reading.js
+++ b/src/build_logic/chain_reading.js
@@ -395,6 +395,8 @@ export async function getBlueRailroadV2s(config) {
         chainId: optimism.id,
     });
 
+    console.log(`Blue Railroad V2 totalSupply: ${totalSupply}`);
+
     let blueRailroadV2s = {};
 
     for (let i = 0; i < totalSupply; i++) {
@@ -445,6 +447,8 @@ export async function getBlueRailroadV2s(config) {
             blockheight: Number(blockheight),
             videoHash: videoHash, // bytes32 as hex string
         };
+
+        console.log(`Blue Railroad V2 #${tokenId}: song ${songId}, blockheight ${blockheight}, owner ${owner}`);
     }
 
     console.timeEnd("Blue Railroad V2s");

--- a/src/build_logic/constants.js
+++ b/src/build_logic/constants.js
@@ -1,6 +1,6 @@
 export const setStoneContractAddress = "0x39269b3FddFc9bf0626e5CFe4424aa51A77f7678";
 export const blueRailroadContractAddress = "0xCe09A2d0d0BDE635722D8EF31901b430E651dB52";
-export const blueRailroadV2ContractAddress = "0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1";
+export const blueRailroadV2ContractAddress = "0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7";
 export const revealerContractAddress = '0xa812137EFf2B368d0B2880A39B609fB60c426850';
 export const ticketStubClaimerContractAddress = "0x1234567890123456789012345678901234567890"; // TODO: Deploy and update with actual address
 

--- a/src/build_logic/enumerable_contracts.json
+++ b/src/build_logic/enumerable_contracts.json
@@ -14,6 +14,12 @@
       "description": "Blue Railroad Train V2 with onchain metadata (songId, blockheight, videoHash)"
     },
     {
+      "name": "BlueRailroadV2",
+      "chainId": 10,
+      "address": "0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1",
+      "description": "Blue Railroad V2 tokens on Optimism"
+    },
+    {
       "name": "SetStone",
       "chainId": 42161,
       "address": "0x39269b3FddFc9bf0626e5CFe4424aa51A77f7678",

--- a/src/build_logic/enumerable_contracts.json
+++ b/src/build_logic/enumerable_contracts.json
@@ -10,14 +10,8 @@
     {
       "name": "BlueRailroadV2",
       "chainId": 10,
-      "address": "0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1",
+      "address": "0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7",
       "description": "Blue Railroad Train V2 with onchain metadata (songId, blockheight, videoHash)"
-    },
-    {
-      "name": "BlueRailroadV2",
-      "chainId": 10,
-      "address": "0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1",
-      "description": "Blue Railroad V2 tokens on Optimism"
     },
     {
       "name": "SetStone",

--- a/src/build_logic/primary_builder.js
+++ b/src/build_logic/primary_builder.js
@@ -80,9 +80,14 @@ export const runPrimaryBuild = async () => {
         }
     }
 
-    // Verify videos early (V1)
-    const blueRailroadMetadata = await verifyBlueRailroadVideos();
-    chainData.blueRailroads = blueRailroadMetadata;
+    // Verify videos early (V1) and merge with chain data
+    const blueRailroadVideoMetadata = await verifyBlueRailroadVideos();
+    // Merge video metadata into existing chain data (chain data has songId, date, ownerDisplay)
+    for (const [tokenId, videoData] of Object.entries(blueRailroadVideoMetadata)) {
+        if (chainData.blueRailroads[tokenId]) {
+            Object.assign(chainData.blueRailroads[tokenId], videoData);
+        }
+    }
 
     // Generate V2 metadata JSON files (cryptograss.live serves these at /meta/bluerailroad/{tokenId})
     if (site === 'cryptograss.live' && chainData.blueRailroadV2s) {
@@ -646,7 +651,7 @@ export const runPrimaryBuild = async () => {
 
     if (site === "cryptograss.live" && pendingSubmissions.length > 0) {
         // Ensure the mint directory exists
-        const mintDir = path.join(outputPrimarySiteDir, 'blox-office/admin/mint');
+        const mintDir = path.join(outputPrimarySiteDir, 'blox-office/admin/mint/bluerailroad/from-pickipedia');
         fs.mkdirSync(mintDir, { recursive: true, mode: 0o777 });
 
         for (const submission of pendingSubmissions) {
@@ -661,12 +666,76 @@ export const runPrimaryBuild = async () => {
 
             renderPage({
                 template_path: 'pages/blox-office/admin/mint-submission.njk',
-                output_path: `blox-office/admin/mint/${submission.id}.html`,
+                output_path: `blox-office/admin/mint/bluerailroad/from-pickipedia/${submission.id}.html`,
                 context: context,
                 site: site,
             });
 
             console.log(`Generated mint page for submission #${submission.id}`);
+        }
+    }
+
+    ///////////////////////////
+    // Chapter 5.6: Blue Railroad V1→V2 Upgrade Pages
+    ///////////////////////////
+
+    // Generate upgrade pages for V1 tokens not yet migrated to V2
+    if (site === "cryptograss.live" && chainData.blueRailroads) {
+        const upgradeDir = path.join(outputPrimarySiteDir, 'blox-office/admin/upgrade/bluerailroad');
+        fs.mkdirSync(upgradeDir, { recursive: true, mode: 0o777 });
+
+        // Find V1 tokens without corresponding V2 tokens
+        const v2TokenIds = new Set(
+            chainData.blueRailroadV2s ? Object.keys(chainData.blueRailroadV2s) : []
+        );
+
+        const v1TokensNeedingUpgrade = Object.entries(chainData.blueRailroads)
+            .filter(([tokenId]) => !v2TokenIds.has(tokenId));
+
+        // Exercise name mapping (same as EXERCISE_MAP in leaderboard.py)
+        const EXERCISE_MAP = {
+            '5': 'Squats (Blue Railroad Train)',
+            '6': 'Pushups (Nine Pound Hammer)',
+            '7': 'Squats (Blue Railroad Train) (legacy)',
+            '10': 'Army Crawls (Ginseng Sullivan)',
+        };
+
+        for (const [tokenId, token] of v1TokensNeedingUpgrade) {
+            const exerciseName = EXERCISE_MAP[String(token.songId)] || `Exercise ID ${token.songId}`;
+
+            const context = {
+                page_name: `upgrade_token_${tokenId}`,
+                page_title: `Upgrade Token #${tokenId} to V2`,
+                submission: {
+                    isUpgrade: true,
+                    v1TokenId: parseInt(tokenId),
+                    v1ContractAddress: '0xCe09A2d0d0BDE635722D8EF31901b430E651dB52',
+                    songId: parseInt(token.songId) || 5,
+                    blockHeight: token.date || 0,  // V1 used 'date' for blockheight
+                    exercise: exerciseName,
+                    // Use locally-served video (Discord CDN URLs expire)
+                    videoUrl: `/assets/fetched/10-0xCe09A2d0d0BDE635722D8EF31901b430E651dB52-${tokenId}.mp4`,
+                    owner: token.owner,
+                    ownerDisplay: token.ownerDisplay,
+                    participants: [],  // Not used for upgrades
+                },
+                chainData: chainData,
+                latest_git_commit: dataAvailableAsContext.latest_git_commit,
+                no_video_bg: true,
+            };
+
+            renderPage({
+                template_path: 'pages/blox-office/admin/mint-submission.njk',
+                output_path: `blox-office/admin/upgrade/bluerailroad/${tokenId}.html`,
+                context: context,
+                site: site,
+            });
+
+            console.log(`Generated upgrade page for V1 Token #${tokenId} (owner: ${token.ownerDisplay || token.owner})`);
+        }
+
+        if (v1TokensNeedingUpgrade.length > 0) {
+            console.log(`Generated ${v1TokensNeedingUpgrade.length} upgrade pages for V1 tokens`);
         }
     }
 

--- a/src/build_logic/webpack.cryptograss.common.js
+++ b/src/build_logic/webpack.cryptograss.common.js
@@ -25,6 +25,8 @@ function buildHtmlPluginInstances() {
             var chunks = ['main', 'oracle_client'];
         } else if (relativePath.startsWith('blox-office/admin/mint/') || relativePath.startsWith('blox-office/admin/upgrade/')) {
             var chunks = ['main', 'mint_submission'];
+        } else if (relativePath.startsWith('blox-office/admin/burn-token')) {
+            var chunks = ['main', 'burn_token'];
         } else {
             var chunks = ['main'];
         }
@@ -103,6 +105,7 @@ export function buildConfig() {
         blue_railroad: `${frontendJSDir}/bazaar/blue_railroad.js`,
         oracle_client: `${frontendJSDir}/oracle_client.js`,
         mint_submission: `${frontendJSDir}/mint-submission.js`,
+        burn_token: `${frontendJSDir}/burn-token.js`,
     },
     module: {
         rules: [

--- a/src/build_logic/webpack.cryptograss.common.js
+++ b/src/build_logic/webpack.cryptograss.common.js
@@ -23,7 +23,7 @@ function buildHtmlPluginInstances() {
 
         if (relativePath.startsWith('tools/oracle-of-bluegrass-bacon')) {
             var chunks = ['main', 'oracle_client'];
-        } else if (relativePath.startsWith('blox-office/admin/mint/')) {
+        } else if (relativePath.startsWith('blox-office/admin/mint/') || relativePath.startsWith('blox-office/admin/upgrade/')) {
             var chunks = ['main', 'mint_submission'];
         } else {
             var chunks = ['main'];

--- a/src/data/cryptograss.live.pages.yaml
+++ b/src/data/cryptograss.live.pages.yaml
@@ -36,4 +36,11 @@ blox-office/admin/pending-submissions:
   context:
     page_title: "Pending Blue Railroad Submissions"
     no_video_bg: true
-    
+
+blox-office/admin/burn-token:
+  template: blox-office/admin/burn-token.njk
+  include_data_in_context: ["chainData", "latest_git_commit"]
+  context:
+    page_title: "Burn Blue Railroad Token"
+    no_video_bg: true
+

--- a/src/sites/cryptograss.live/js/burn-token.js
+++ b/src/sites/cryptograss.live/js/burn-token.js
@@ -1,0 +1,300 @@
+/**
+ * Blue Railroad Token Burn Page
+ * Handles wallet connection and token burning (transfer to 0x...dEaD)
+ */
+
+import { createAppKit } from '@reown/appkit';
+import { optimism } from '@reown/appkit/networks';
+import { WagmiAdapter } from '@reown/appkit-adapter-wagmi';
+import { reconnect, getAccount, writeContract, readContract, waitForTransactionReceipt } from '@wagmi/core';
+
+// Burn address - the standard "dead" address
+const BURN_ADDRESS = '0x000000000000000000000000000000000000dEaD';
+
+// Blue Railroad V1 contract config
+const BR_V1_CONTRACT = '0xCe09A2d0d0BDE635722D8EF31901b430E651dB52';
+const BR_V1_ABI = [
+    {
+        inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
+        name: 'ownerOf',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'from', type: 'address' },
+            { internalType: 'address', name: 'to', type: 'address' },
+            { internalType: 'uint256', name: 'tokenId', type: 'uint256' }
+        ],
+        name: 'transferFrom',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    }
+];
+
+// Blue Railroad V2 contract config
+const BR_V2_CONTRACT = '0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7';
+const BR_V2_ABI = [
+    {
+        inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
+        name: 'ownerOf',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'from', type: 'address' },
+            { internalType: 'address', name: 'to', type: 'address' },
+            { internalType: 'uint256', name: 'tokenId', type: 'uint256' }
+        ],
+        name: 'transferFrom',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    }
+];
+
+// Setup Web3Modal
+const projectId = 'c4f79cc821d56e59de850c9b35cbbe86';
+const metadata = {
+    name: 'Blue Railroad Admin',
+    description: 'Burn Blue Railroad tokens',
+    url: 'https://cryptograss.live',
+    icons: ['https://cryptograss.live/favicon.ico']
+};
+
+const wagmiAdapter = new WagmiAdapter({
+    projectId,
+    networks: [optimism]
+});
+
+const modal = createAppKit({
+    adapters: [wagmiAdapter],
+    networks: [optimism],
+    metadata,
+    projectId,
+    features: { analytics: false }
+});
+
+const wagmiConfig = wagmiAdapter.wagmiConfig;
+
+// Get contract config based on version
+function getContractConfig(version) {
+    if (version === 'v1') {
+        return { address: BR_V1_CONTRACT, abi: BR_V1_ABI };
+    }
+    return { address: BR_V2_CONTRACT, abi: BR_V2_ABI };
+}
+
+// Initialize on page load
+export function initBurnPage() {
+    // Reconnect any existing wallet sessions
+    reconnect(wagmiConfig);
+
+    // DOM elements
+    const tokenIdInput = document.getElementById('token-id');
+    const contractSelect = document.getElementById('contract-select');
+    const checkTokenBtn = document.getElementById('check-token-btn');
+    const tokenInfo = document.getElementById('token-info');
+    const tokenOwner = document.getElementById('token-owner');
+    const tokenError = document.getElementById('token-error');
+
+    const connectBtn = document.getElementById('connect-wallet-btn');
+    const notConnectedMsg = document.getElementById('not-connected-msg');
+    const connectedAddress = document.getElementById('connected-address');
+
+    const burnBtn = document.getElementById('burn-btn');
+    const statusArea = document.getElementById('status-area');
+    const pendingMsg = document.getElementById('pending-msg');
+    const pendingText = document.getElementById('pending-text');
+    const successMsg = document.getElementById('success-msg');
+    const successText = document.getElementById('success-text');
+    const txLink = document.getElementById('tx-link');
+    const errorMsg = document.getElementById('error-msg');
+
+    let currentTokenOwner = null;
+
+    // Wallet connection UI update
+    function updateWalletUI() {
+        const account = getAccount(wagmiConfig);
+        if (account.address) {
+            notConnectedMsg.style.display = 'none';
+            connectedAddress.style.display = 'block';
+            connectedAddress.textContent = `Connected: ${account.address.slice(0, 6)}...${account.address.slice(-4)}`;
+            connectBtn.textContent = 'Connected';
+            updateBurnButtonState();
+        } else {
+            notConnectedMsg.style.display = 'block';
+            connectedAddress.style.display = 'none';
+            connectBtn.textContent = 'Connect Wallet';
+            burnBtn.disabled = true;
+        }
+    }
+
+    // Update burn button state based on ownership
+    function updateBurnButtonState() {
+        const account = getAccount(wagmiConfig);
+        if (!account.address || !currentTokenOwner) {
+            burnBtn.disabled = true;
+            return;
+        }
+
+        const userOwnsToken = account.address.toLowerCase() === currentTokenOwner.toLowerCase();
+        burnBtn.disabled = !userOwnsToken;
+
+        if (!userOwnsToken && currentTokenOwner) {
+            tokenError.textContent = 'You do not own this token. Only the owner can burn it.';
+            tokenError.style.display = 'block';
+        }
+    }
+
+    // Connect wallet button
+    connectBtn.addEventListener('click', () => {
+        modal.open();
+    });
+
+    // Subscribe to wallet state changes
+    wagmiAdapter.wagmiConfig.subscribe(
+        (state) => state.current,
+        () => updateWalletUI()
+    );
+
+    // Check token ownership
+    checkTokenBtn.addEventListener('click', async () => {
+        const tokenId = tokenIdInput.value.trim();
+        const version = contractSelect.value;
+
+        if (!tokenId) {
+            tokenError.textContent = 'Please enter a token ID';
+            tokenError.style.display = 'block';
+            tokenInfo.style.display = 'none';
+            return;
+        }
+
+        tokenError.style.display = 'none';
+        tokenInfo.style.display = 'none';
+        checkTokenBtn.disabled = true;
+        checkTokenBtn.textContent = 'Checking...';
+
+        try {
+            const { address, abi } = getContractConfig(version);
+
+            const owner = await readContract(wagmiConfig, {
+                address,
+                abi,
+                functionName: 'ownerOf',
+                args: [BigInt(tokenId)],
+                chainId: 10
+            });
+
+            currentTokenOwner = owner;
+            tokenOwner.textContent = `${owner.slice(0, 6)}...${owner.slice(-4)}`;
+            tokenInfo.style.display = 'block';
+
+            // Check if this is already the burn address
+            if (owner.toLowerCase() === BURN_ADDRESS.toLowerCase()) {
+                tokenError.textContent = 'This token has already been burned!';
+                tokenError.style.display = 'block';
+                burnBtn.disabled = true;
+            } else {
+                updateBurnButtonState();
+            }
+
+        } catch (err) {
+            console.error('Token check error:', err);
+            currentTokenOwner = null;
+
+            if (err.message?.includes('ERC721NonexistentToken') ||
+                err.message?.includes('owner query for nonexistent token')) {
+                tokenError.textContent = `Token #${tokenId} does not exist on the ${version.toUpperCase()} contract`;
+            } else {
+                tokenError.textContent = 'Error checking token: ' + (err.shortMessage || err.message);
+            }
+            tokenError.style.display = 'block';
+            burnBtn.disabled = true;
+        } finally {
+            checkTokenBtn.disabled = false;
+            checkTokenBtn.textContent = 'Check Token';
+        }
+    });
+
+    // Burn token handler
+    burnBtn.addEventListener('click', async () => {
+        const tokenId = tokenIdInput.value.trim();
+        const version = contractSelect.value;
+        const account = getAccount(wagmiConfig);
+
+        if (!account.address) {
+            errorMsg.textContent = 'Please connect your wallet first';
+            errorMsg.style.display = 'block';
+            return;
+        }
+
+        if (!tokenId || !currentTokenOwner) {
+            errorMsg.textContent = 'Please check the token first';
+            errorMsg.style.display = 'block';
+            return;
+        }
+
+        statusArea.style.display = 'block';
+        pendingMsg.style.display = 'block';
+        successMsg.style.display = 'none';
+        errorMsg.style.display = 'none';
+        burnBtn.disabled = true;
+        pendingText.textContent = `Burning token #${tokenId}...`;
+
+        try {
+            const { address, abi } = getContractConfig(version);
+
+            const hash = await writeContract(wagmiConfig, {
+                address,
+                abi,
+                functionName: 'transferFrom',
+                args: [account.address, BURN_ADDRESS, BigInt(tokenId)],
+                chainId: 10
+            });
+
+            pendingText.textContent = 'Waiting for confirmation...';
+
+            await waitForTransactionReceipt(wagmiConfig, {
+                hash,
+                chainId: 10
+            });
+
+            pendingMsg.style.display = 'none';
+            successMsg.style.display = 'block';
+            successText.textContent = `Token #${tokenId} has been burned!`;
+            txLink.innerHTML = `<a href="https://optimistic.etherscan.io/tx/${hash}" target="_blank" class="btn btn-sm btn-outline-success">View Transaction</a>`;
+
+            // Reset the form
+            currentTokenOwner = null;
+            tokenInfo.style.display = 'none';
+            tokenIdInput.value = '';
+
+        } catch (err) {
+            console.error('Burn error:', err);
+            pendingMsg.style.display = 'none';
+
+            let errorMessage = err.message || 'Transaction failed';
+            if (err.shortMessage) {
+                errorMessage = err.shortMessage;
+            }
+            if (errorMessage.includes('User rejected') || errorMessage.includes('user rejected')) {
+                errorMessage = 'Transaction cancelled by user';
+            }
+
+            errorMsg.textContent = errorMessage;
+            errorMsg.style.display = 'block';
+            burnBtn.disabled = false;
+        }
+    });
+
+    // Initial UI update
+    updateWalletUI();
+}
+
+// Make it available globally for the template to call
+window.initBurnPage = initBurnPage;

--- a/src/sites/cryptograss.live/js/mint-submission.js
+++ b/src/sites/cryptograss.live/js/mint-submission.js
@@ -1,53 +1,218 @@
 /**
- * Blue Railroad Mint Submission Page
- * Handles wallet connection, IPFS pinning, and token minting
+ * Blue Railroad Mint/Upgrade Page
+ * Handles wallet connection, IPFS pinning, and token minting or V1→V2 migration
  */
 
 import { createAppKit } from '@reown/appkit';
 import { optimism } from '@reown/appkit/networks';
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi';
-import { reconnect, getAccount, writeContract, waitForTransactionReceipt, signMessage, getEnsAddress } from '@wagmi/core';
+import { reconnect, getAccount, writeContract, readContract, waitForTransactionReceipt, signMessage, getEnsAddress } from '@wagmi/core';
 import { mainnet } from '@reown/appkit/networks';
 
+// Blue Railroad V1 contract config
+const BR_V1_CONTRACT = '0xCe09A2d0d0BDE635722D8EF31901b430E651dB52';
+const BR_V1_ABI = [
+    {
+        inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
+        name: 'ownerOf',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
+        name: 'getApproved',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'to', type: 'address' },
+            { internalType: 'uint256', name: 'tokenId', type: 'uint256' }
+        ],
+        name: 'approve',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    }
+];
+
 // Blue Railroad V2 contract config
-const BR_CONTRACT = '0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1';
-const BR_ABI = [{
-    inputs: [
-        { internalType: 'address', name: 'recipient', type: 'address' },
-        { internalType: 'uint8', name: 'songId', type: 'uint8' },
-        { internalType: 'uint256', name: 'blockheight', type: 'uint256' },
-        { internalType: 'bytes32', name: 'videoHash', type: 'bytes32' }
-    ],
-    name: 'issueTony',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function'
-}];
+const BR_V2_CONTRACT = '0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7';
+const BR_V2_ABI = [
+    {
+        inputs: [
+            { internalType: 'address', name: 'recipient', type: 'address' },
+            { internalType: 'uint8', name: 'songId', type: 'uint8' },
+            { internalType: 'uint256', name: 'blockheight', type: 'uint256' },
+            { internalType: 'bytes32', name: 'videoHash', type: 'bytes32' }
+        ],
+        name: 'issueTony',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    },
+    {
+        inputs: [
+            { internalType: 'uint32', name: 'v1TokenId', type: 'uint32' },
+            { internalType: 'uint8', name: 'songId', type: 'uint8' },
+            { internalType: 'uint256', name: 'blockheight', type: 'uint256' },
+            { internalType: 'bytes32', name: 'videoHash', type: 'bytes32' }
+        ],
+        name: 'migrateFromV1',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    }
+];
+
+// Base58 alphabet for CIDv0 decoding
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+// Base32 alphabet for CIDv1 decoding (RFC 4648, lowercase)
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+function base58Decode(str) {
+    const bytes = [];
+    for (let i = 0; i < str.length; i++) {
+        const char = str[i];
+        const index = BASE58_ALPHABET.indexOf(char);
+        if (index === -1) throw new Error(`Invalid base58 character: ${char}`);
+
+        let carry = index;
+        for (let j = 0; j < bytes.length; j++) {
+            carry += bytes[j] * 58;
+            bytes[j] = carry & 0xff;
+            carry >>= 8;
+        }
+        while (carry > 0) {
+            bytes.push(carry & 0xff);
+            carry >>= 8;
+        }
+    }
+
+    // Handle leading zeros
+    for (let i = 0; i < str.length && str[i] === '1'; i++) {
+        bytes.push(0);
+    }
+
+    return new Uint8Array(bytes.reverse());
+}
+
+function base32Decode(str) {
+    // Remove padding if present
+    str = str.replace(/=+$/, '').toLowerCase();
+
+    let bits = 0;
+    let value = 0;
+    const output = [];
+
+    for (let i = 0; i < str.length; i++) {
+        const char = str[i];
+        const index = BASE32_ALPHABET.indexOf(char);
+        if (index === -1) throw new Error(`Invalid base32 character: ${char}`);
+
+        value = (value << 5) | index;
+        bits += 5;
+
+        if (bits >= 8) {
+            output.push((value >>> (bits - 8)) & 0xff);
+            bits -= 8;
+        }
+    }
+
+    return new Uint8Array(output);
+}
+
+// Read a varint from bytes at given offset, return [value, bytesRead]
+function readVarint(bytes, offset) {
+    let value = 0;
+    let shift = 0;
+    let bytesRead = 0;
+
+    while (offset + bytesRead < bytes.length) {
+        const byte = bytes[offset + bytesRead];
+        value |= (byte & 0x7f) << shift;
+        bytesRead++;
+        if ((byte & 0x80) === 0) break;
+        shift += 7;
+    }
+
+    return [value, bytesRead];
+}
 
 // Convert IPFS CID to bytes32 hash
-// For CIDv0 (Qm...), extract the sha256 digest
-// For CIDv1 or raw hash, use directly
+// Supports both CIDv0 (Qm...) and CIDv1 (bafy...)
 function cidToBytes32(cid) {
     if (!cid) return '0x0000000000000000000000000000000000000000000000000000000000000000';
 
-    // If it's already a hex string (0x...), return as-is padded to 32 bytes
+    // If it's already a hex string (0x...), validate and return
     if (cid.startsWith('0x')) {
-        return cid.padEnd(66, '0');
+        if (cid.length === 66) return cid;
+        throw new Error('Invalid bytes32 hex string');
     }
 
-    // CIDv0 starts with Qm and is base58 encoded
-    // For simplicity, we'll store the CID as UTF-8 bytes in the hash
-    // A proper implementation would decode the multihash
-    // For now, just hash the CID string
-    const encoder = new TextEncoder();
-    const data = encoder.encode(cid);
+    let hashBytes;
 
-    // Simple hash: take first 32 bytes or pad with zeros
-    let hex = '0x';
-    for (let i = 0; i < 32; i++) {
-        hex += (data[i] || 0).toString(16).padStart(2, '0');
+    // CIDv0 starts with Qm (base58btc encoded)
+    if (cid.startsWith('Qm')) {
+        const decoded = base58Decode(cid);
+
+        // CIDv0 structure: 0x12 (sha256) + 0x20 (32 bytes) + 32 bytes hash
+        if (decoded.length !== 34) {
+            throw new Error(`Invalid CIDv0 length: expected 34 bytes, got ${decoded.length}`);
+        }
+        if (decoded[0] !== 0x12 || decoded[1] !== 0x20) {
+            throw new Error('Invalid CIDv0 prefix: expected sha256 multihash');
+        }
+
+        hashBytes = decoded.slice(2);
     }
-    return hex;
+    // CIDv1 starts with 'b' (base32lower) - common format is bafy... or bafybei...
+    else if (cid.startsWith('b')) {
+        // Remove the 'b' multibase prefix and decode base32
+        const decoded = base32Decode(cid.slice(1));
+
+        let offset = 0;
+
+        // Read CID version (should be 1)
+        const [version, versionBytes] = readVarint(decoded, offset);
+        offset += versionBytes;
+        if (version !== 1) {
+            throw new Error(`Unexpected CID version: ${version}`);
+        }
+
+        // Read codec (0x70 = dag-pb, 0x55 = raw, 0x71 = dag-cbor)
+        const [codec, codecBytes] = readVarint(decoded, offset);
+        offset += codecBytes;
+        // We don't need the codec value, just skip it
+
+        // Read multihash: hash function code
+        const [hashFn, hashFnBytes] = readVarint(decoded, offset);
+        offset += hashFnBytes;
+        if (hashFn !== 0x12) {
+            throw new Error(`Unsupported hash function: 0x${hashFn.toString(16)} (expected sha256 0x12)`);
+        }
+
+        // Read multihash: digest length
+        const [digestLen, digestLenBytes] = readVarint(decoded, offset);
+        offset += digestLenBytes;
+        if (digestLen !== 32) {
+            throw new Error(`Unexpected digest length: ${digestLen} (expected 32)`);
+        }
+
+        // Extract the 32-byte hash
+        hashBytes = decoded.slice(offset, offset + 32);
+        if (hashBytes.length !== 32) {
+            throw new Error(`Could not extract 32-byte hash from CIDv1`);
+        }
+    }
+    else {
+        throw new Error('Unsupported CID format. Expected CIDv0 (Qm...) or CIDv1 (b...)');
+    }
+
+    return '0x' + Array.from(hashBytes).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
 // Setup Web3Modal
@@ -100,11 +265,19 @@ export function initMintPage(submissionData) {
         videoUrl,
         recipients,
         pinningService,
-        pickipediaUrl
+        pickipediaUrl,
+        // Upgrade-specific fields
+        isUpgrade = false,
+        v1TokenId = null
     } = submissionData;
 
+    // Convert relative video URLs to absolute (needed for external pinning service)
+    const absoluteVideoUrl = videoUrl && videoUrl.startsWith('/')
+        ? new URL(videoUrl, window.location.origin).href
+        : videoUrl;
+
     // Current video URI - starts as the original URL, updated if pinned to IPFS
-    let currentVideoUri = videoUrl;
+    let currentVideoUri = absoluteVideoUrl;
     let currentIpfsCid = null; // Track the CID separately for bytes32 conversion
 
     // Reconnect any existing wallet sessions
@@ -124,7 +297,15 @@ export function initMintPage(submissionData) {
     const ipfsCid = document.getElementById('ipfs-cid');
     const pinError = document.getElementById('pin-error');
 
-    // DOM elements - minting
+    // DOM elements - approval (upgrade only)
+    const approvalSection = document.getElementById('approval-section');
+    const approveBtn = document.getElementById('approve-btn');
+    const approvalNotStarted = document.getElementById('approval-not-started');
+    const approvalInProgress = document.getElementById('approval-in-progress');
+    const approvalComplete = document.getElementById('approval-complete');
+    const approvalError = document.getElementById('approval-error');
+
+    // DOM elements - minting/migration
     const mintBtn = document.getElementById('mint-btn');
     const statusArea = document.getElementById('status-area');
     const pendingMsg = document.getElementById('pending-msg');
@@ -133,6 +314,9 @@ export function initMintPage(submissionData) {
     const successText = document.getElementById('success-text');
     const txLinks = document.getElementById('tx-links');
     const errorMsg = document.getElementById('error-msg');
+
+    // Track approval state for upgrades
+    let isApproved = false;
 
     // Wallet connection UI update
     function updateWalletUI() {
@@ -143,13 +327,13 @@ export function initMintPage(submissionData) {
             connectedAddress.textContent = account.address;
             connectBtn.textContent = 'Connected';
             mintBtn.disabled = false;
-            if (pinBtn) pinBtn.disabled = false;
+            // Clear any previous "connect wallet" error when wallet connects
+            if (pinError) pinError.style.display = 'none';
         } else {
             notConnectedMsg.style.display = 'block';
             connectedAddress.style.display = 'none';
             connectBtn.textContent = 'Connect Wallet';
             mintBtn.disabled = true;
-            if (pinBtn) pinBtn.disabled = true;
         }
     }
 
@@ -169,8 +353,10 @@ export function initMintPage(submissionData) {
         pinBtn.addEventListener('click', async () => {
             const account = getAccount(wagmiConfig);
             if (!account.address) {
-                pinError.textContent = 'Please connect your wallet first';
+                pinError.innerHTML = '<strong>Wallet not connected.</strong> Please connect your wallet first (Step 1 above).';
                 pinError.style.display = 'block';
+                // Scroll to make sure error is visible
+                pinError.scrollIntoView({ behavior: 'smooth', block: 'center' });
                 return;
             }
 
@@ -203,7 +389,7 @@ export function initMintPage(submissionData) {
                         'X-Signature': signature,
                         'X-Timestamp': timestamp.toString()
                     },
-                    body: JSON.stringify({ url: videoUrl })
+                    body: JSON.stringify({ url: absoluteVideoUrl })
                 });
 
                 if (!response.ok) {
@@ -241,7 +427,84 @@ export function initMintPage(submissionData) {
         });
     }
 
-    // Mint handler
+    // Approval handler (upgrades only)
+    if (isUpgrade && approveBtn) {
+        approveBtn.addEventListener('click', async () => {
+            const account = getAccount(wagmiConfig);
+            if (!account.address) {
+                approvalError.innerHTML = '<strong>Wallet not connected.</strong> Please connect your wallet first.';
+                approvalError.style.display = 'block';
+                return;
+            }
+
+            approveBtn.disabled = true;
+            approvalNotStarted.style.display = 'none';
+            approvalInProgress.style.display = 'block';
+            approvalError.style.display = 'none';
+
+            try {
+                // Check if user owns the V1 token
+                const owner = await readContract(wagmiConfig, {
+                    address: BR_V1_CONTRACT,
+                    abi: BR_V1_ABI,
+                    functionName: 'ownerOf',
+                    args: [v1TokenId],
+                    chainId: 10
+                });
+
+                if (owner.toLowerCase() !== account.address.toLowerCase()) {
+                    throw new Error(`You don't own V1 Token #${v1TokenId}. Current owner: ${owner.slice(0, 10)}...`);
+                }
+
+                // Check if already approved
+                const approvedFor = await readContract(wagmiConfig, {
+                    address: BR_V1_CONTRACT,
+                    abi: BR_V1_ABI,
+                    functionName: 'getApproved',
+                    args: [v1TokenId],
+                    chainId: 10
+                });
+
+                if (approvedFor.toLowerCase() === BR_V2_CONTRACT.toLowerCase()) {
+                    // Already approved
+                    isApproved = true;
+                    approvalInProgress.style.display = 'none';
+                    approvalComplete.style.display = 'block';
+                    approvalComplete.innerHTML = '<span class="badge bg-success">Already Approved</span>';
+                    mintBtn.disabled = false;
+                    return;
+                }
+
+                // Send approval transaction
+                const hash = await writeContract(wagmiConfig, {
+                    address: BR_V1_CONTRACT,
+                    abi: BR_V1_ABI,
+                    functionName: 'approve',
+                    args: [BR_V2_CONTRACT, v1TokenId],
+                    chainId: 10
+                });
+
+                await waitForTransactionReceipt(wagmiConfig, {
+                    hash,
+                    chainId: 10
+                });
+
+                isApproved = true;
+                approvalInProgress.style.display = 'none';
+                approvalComplete.style.display = 'block';
+                mintBtn.disabled = false;
+            } catch (err) {
+                console.error('Approval error:', err);
+                approvalInProgress.style.display = 'none';
+                approvalNotStarted.style.display = 'block';
+                approvalError.textContent = 'Approval failed: ' + err.message;
+                approvalError.style.display = 'block';
+                approveBtn.disabled = false;
+            }
+        });
+    }
+
+    // Mint/Migrate handler
     mintBtn.addEventListener('click', async () => {
         statusArea.style.display = 'block';
         pendingMsg.style.display = 'block';
@@ -252,48 +515,83 @@ export function initMintPage(submissionData) {
         const txResults = [];
 
         try {
-            for (let i = 0; i < recipients.length; i++) {
-                const recipientInput = recipients[i];
-                pendingText.textContent = `Resolving ${recipientInput}...`;
+            // Convert IPFS CID to bytes32 for V2 contract
+            const videoHash = cidToBytes32(currentIpfsCid);
 
-                // Resolve ENS name if needed
-                const recipient = await resolveRecipient(recipientInput);
-                pendingText.textContent = `Minting token ${i + 1} of ${recipients.length} for ${recipientInput}...`;
-
-                // Convert IPFS CID to bytes32 for V2 contract
-                const videoHash = cidToBytes32(currentIpfsCid);
+            if (isUpgrade) {
+                // V1→V2 migration flow
+                pendingText.textContent = `Migrating V1 Token #${v1TokenId} to V2...`;
 
                 const hash = await writeContract(wagmiConfig, {
-                    address: BR_CONTRACT,
-                    abi: BR_ABI,
-                    functionName: 'issueTony',
-                    args: [recipient, songId, blockHeight, videoHash],
+                    address: BR_V2_CONTRACT,
+                    abi: BR_V2_ABI,
+                    functionName: 'migrateFromV1',
+                    args: [v1TokenId, songId, blockHeight, videoHash],
                     chainId: 10
                 });
 
-                pendingText.textContent = `Waiting for confirmation (${i + 1}/${recipients.length})...`;
+                pendingText.textContent = 'Waiting for confirmation...';
 
                 await waitForTransactionReceipt(wagmiConfig, {
                     hash,
                     chainId: 10
                 });
 
-                txResults.push({ recipient: recipientInput, resolvedAddress: recipient, hash, success: true });
+                txResults.push({ tokenId: v1TokenId, hash, success: true });
+
+                pendingMsg.style.display = 'none';
+                successMsg.style.display = 'block';
+                successText.textContent = `Successfully migrated Token #${v1TokenId} to V2!`;
+            } else {
+                // Standard minting flow
+                for (let i = 0; i < recipients.length; i++) {
+                    const recipientInput = recipients[i];
+                    pendingText.textContent = `Resolving ${recipientInput}...`;
+
+                    // Resolve ENS name if needed
+                    const recipient = await resolveRecipient(recipientInput);
+                    pendingText.textContent = `Minting token ${i + 1} of ${recipients.length} for ${recipientInput}...`;
+
+                    const hash = await writeContract(wagmiConfig, {
+                        address: BR_V2_CONTRACT,
+                        abi: BR_V2_ABI,
+                        functionName: 'issueTony',
+                        args: [recipient, songId, blockHeight, videoHash],
+                        chainId: 10
+                    });
+
+                    pendingText.textContent = `Waiting for confirmation (${i + 1}/${recipients.length})...`;
+
+                    await waitForTransactionReceipt(wagmiConfig, {
+                        hash,
+                        chainId: 10
+                    });
+
+                    txResults.push({ recipient: recipientInput, resolvedAddress: recipient, hash, success: true });
+                }
+
+                pendingMsg.style.display = 'none';
+                successMsg.style.display = 'block';
+                successText.textContent = `Successfully minted ${txResults.length} token${txResults.length > 1 ? 's' : ''}!`;
             }
 
-            pendingMsg.style.display = 'none';
-            successMsg.style.display = 'block';
-            successText.textContent = `Successfully minted ${txResults.length} token${txResults.length > 1 ? 's' : ''}!`;
-
             // Build transaction links
-            let linksHtml = txResults.map(r =>
-                `<div><a href="https://optimistic.etherscan.io/tx/${r.hash}" target="_blank">${r.recipient.slice(0, 10)}... → View TX</a></div>`
-            ).join('');
+            let linksHtml;
+            if (isUpgrade) {
+                linksHtml = txResults.map(r =>
+                    `<div><a href="https://optimistic.etherscan.io/tx/${r.hash}" target="_blank">Token #${r.tokenId} → View TX</a></div>`
+                ).join('');
+            } else {
+                linksHtml = txResults.map(r =>
+                    `<div><a href="https://optimistic.etherscan.io/tx/${r.hash}" target="_blank">${r.recipient.slice(0, 10)}... → View TX</a></div>`
+                ).join('');
+            }
 
             // Add reminder to update wiki status
             if (pickipediaUrl) {
+                const actionText = isUpgrade ? 'Upgraded' : 'Minted';
                 linksHtml += `<div class="mt-3 p-2 border rounded bg-light">
-                    <strong>Next step:</strong> Update the submission status to "Minted" on PickiPedia<br>
+                    <strong>Next step:</strong> Update the submission status to "${actionText}" on PickiPedia<br>
                     <a href="${pickipediaUrl}?action=edit" target="_blank" class="btn btn-sm btn-outline-primary mt-1">Edit Submission Page</a>
                 </div>`;
             }

--- a/src/sites/cryptograss.live/templates/pages/blox-office/admin/burn-token.njk
+++ b/src/sites/cryptograss.live/templates/pages/blox-office/admin/burn-token.njk
@@ -1,0 +1,113 @@
+{% extends '../../../base.njk' %}
+{% block main %}
+
+<div class="row">
+    <div class="col-1"></div>
+    <div class="col-md-10 text-post">
+        <h1 class="text-center pixel-font">Burn Blue Railroad Token</h1>
+        <p class="text-center text-muted">Send a token to the burn address (0x...dEaD)</p>
+
+        <div class="row mt-4">
+            <div class="col-md-6 offset-md-3">
+                <!-- Token ID Input -->
+                <div class="card semi-transparent-bg mb-4">
+                    <div class="card-body">
+                        <h5 class="card-title">Token Details</h5>
+                        <div class="mb-3">
+                            <label for="token-id" class="form-label">Token ID to Burn</label>
+                            <input type="number" class="form-control" id="token-id" placeholder="e.g., 7" min="0">
+                        </div>
+                        <div id="token-info" style="display: none;">
+                            <dl class="row mb-0">
+                                <dt class="col-sm-4">Owner</dt>
+                                <dd class="col-sm-8"><code id="token-owner"></code></dd>
+                                <dt class="col-sm-4">Contract</dt>
+                                <dd class="col-sm-8">
+                                    <select id="contract-select" class="form-select form-select-sm">
+                                        <option value="v2" selected>V2 (0x7C3a...B4B7)</option>
+                                        <option value="v1">V1 (0xCe09...dB52)</option>
+                                    </select>
+                                </dd>
+                            </dl>
+                        </div>
+                        <div id="token-error" class="alert alert-danger mt-2" style="display: none;"></div>
+                        <button id="check-token-btn" class="btn btn-outline-primary mt-2">Check Token</button>
+                    </div>
+                </div>
+
+                <!-- Wallet Connection -->
+                <div class="card semi-transparent-bg mb-4">
+                    <div class="card-body">
+                        <h5 class="card-title">1. Connect Wallet</h5>
+                        <div id="wallet-status">
+                            <p id="not-connected-msg">Not connected</p>
+                            <p id="connected-address" style="display: none;" class="font-monospace"></p>
+                        </div>
+                        <button id="connect-wallet-btn" class="btn btn-primary">Connect Wallet</button>
+                    </div>
+                </div>
+
+                <!-- Burn Action -->
+                <div class="card semi-transparent-bg">
+                    <div class="card-body">
+                        <h5 class="card-title">2. Burn Token</h5>
+                        <p class="text-muted small">
+                            This will transfer the token to the burn address:<br>
+                            <code>0x000000000000000000000000000000000000dEaD</code>
+                        </p>
+                        <p class="text-warning small">
+                            <strong>Warning:</strong> This action is irreversible!
+                        </p>
+
+                        <div class="d-grid gap-2">
+                            <button id="burn-btn" class="btn btn-danger btn-lg" disabled>
+                                Burn Token
+                            </button>
+                        </div>
+
+                        <!-- Status messages -->
+                        <div id="status-area" class="mt-3" style="display: none;">
+                            <div id="pending-msg" class="alert alert-info" style="display: none;">
+                                <span class="spinner-border spinner-border-sm" role="status"></span>
+                                <span id="pending-text">Transaction pending...</span>
+                            </div>
+                            <div id="success-msg" class="alert alert-success" style="display: none;">
+                                <div id="success-text">Token burned!</div>
+                                <div id="tx-link" class="mt-2"></div>
+                            </div>
+                            <div id="error-msg" class="alert alert-danger" style="display: none;"></div>
+                        </div>
+                    </div>
+                </div>
+
+                {% include 'partials/build-metadata.njk' %}
+            </div>
+        </div>
+    </div>
+    <div class="col-1"></div>
+</div>
+
+<style>
+.pixel-font {
+    font-family: 'Courier New', monospace;
+    font-weight: bold;
+}
+:root {
+    --w3m-z-index: 10000 !important;
+}
+w3m-modal {
+    z-index: 10000 !important;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    if (window.initBurnPage) {
+        window.initBurnPage();
+    } else {
+        console.error('burn-token.js not loaded - initBurnPage not found');
+    }
+});
+</script>
+
+{% endblock %}

--- a/src/sites/cryptograss.live/templates/pages/blox-office/admin/mint-submission.njk
+++ b/src/sites/cryptograss.live/templates/pages/blox-office/admin/mint-submission.njk
@@ -4,14 +4,52 @@
 <div class="row">
     <div class="col-1"></div>
     <div class="col-md-10 text-post">
+        {% if submission.isUpgrade %}
+        <h1 class="text-center pixel-font">Upgrade Token #{{ submission.v1TokenId }} to V2</h1>
+        <p class="text-center text-muted">Migrate from V1 contract with updated metadata</p>
+        {% else %}
         <h1 class="text-center pixel-font">Mint Submission #{{ submission.id }}</h1>
         <p class="text-center text-muted">{{ submission.exercise }}</p>
+        {% endif %}
 
         <div class="row mt-4">
             <div class="col-md-8 offset-md-2">
-                <!-- Submission Details -->
+                <!-- Submission/Upgrade Details -->
                 <div class="card semi-transparent-bg mb-4">
                     <div class="card-body">
+                        {% if submission.isUpgrade %}
+                        <h5 class="card-title">Upgrade Details</h5>
+                        <dl class="row mb-0">
+                            <dt class="col-sm-4">V1 Token ID</dt>
+                            <dd class="col-sm-8">
+                                <a href="https://opensea.io/assets/optimism/{{ submission.v1ContractAddress | default('0xCe09A2d0d0BDE635722D8EF31901b430E651dB52') }}/{{ submission.v1TokenId }}" target="_blank">
+                                    #{{ submission.v1TokenId }}
+                                </a>
+                            </dd>
+
+                            <dt class="col-sm-4">Exercise</dt>
+                            <dd class="col-sm-8">{{ submission.exercise }}</dd>
+
+                            <dt class="col-sm-4">Song ID</dt>
+                            <dd class="col-sm-8"><code>{{ submission.songId }}</code></dd>
+
+                            <dt class="col-sm-4">Block Height</dt>
+                            <dd class="col-sm-8">
+                                {% if submission.blockHeight %}
+                                <a href="https://etherscan.io/block/{{ submission.blockHeight }}" target="_blank">
+                                    {{ submission.blockHeight }}
+                                </a>
+                                {% else %}—{% endif %}
+                            </dd>
+
+                            {% if submission.videoUrl %}
+                            <dt class="col-sm-4">Video</dt>
+                            <dd class="col-sm-8">
+                                <a href="{{ submission.videoUrl }}" target="_blank">View Video</a>
+                            </dd>
+                            {% endif %}
+                        </dl>
+                        {% else %}
                         <h5 class="card-title">Submission Details</h5>
                         <dl class="row mb-0">
                             <dt class="col-sm-4">Exercise</dt>
@@ -50,6 +88,19 @@
                                 <a href="{{ submission.url }}" target="_blank">View Submission</a>
                             </dd>
                         </dl>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <!-- Wallet Connection -->
+                <div class="card semi-transparent-bg mb-4">
+                    <div class="card-body">
+                        <h5 class="card-title">1. Connect Wallet</h5>
+                        <div id="wallet-status">
+                            <p id="not-connected-msg">Not connected</p>
+                            <p id="connected-address" style="display: none;" class="font-monospace"></p>
+                        </div>
+                        <button id="connect-wallet-btn" class="btn btn-primary">Connect Wallet</button>
                     </div>
                 </div>
 
@@ -57,7 +108,7 @@
                 {% if submission.videoUrl %}
                 <div class="card semi-transparent-bg mb-4">
                     <div class="card-body">
-                        <h5 class="card-title">Video Pinning</h5>
+                        <h5 class="card-title">2. Pin Video to IPFS</h5>
                         <p class="small text-muted mb-2">Pin the video to IPFS for permanent storage before minting.</p>
 
                         <div id="pin-status" class="mb-3">
@@ -76,30 +127,63 @@
                             <div id="pin-error" class="alert alert-danger mt-2" style="display: none;"></div>
                         </div>
 
-                        <button id="pin-btn" class="btn btn-outline-primary" disabled>
+                        <button id="pin-btn" class="btn btn-outline-primary">
                             Pin to IPFS
                         </button>
-                        <small class="text-muted d-block mt-1">Requires wallet connection</small>
                     </div>
                 </div>
                 {% endif %}
 
-                <!-- Wallet Connection -->
-                <div class="card semi-transparent-bg mb-4">
+                <!-- V1 Approval (upgrade only) -->
+                {% if submission.isUpgrade %}
+                <div class="card semi-transparent-bg mb-4" id="approval-section">
                     <div class="card-body">
-                        <h5 class="card-title">Wallet</h5>
-                        <div id="wallet-status">
-                            <p id="not-connected-msg">Not connected</p>
-                            <p id="connected-address" style="display: none;" class="font-monospace"></p>
+                        <h5 class="card-title">3. Approve V2 Contract</h5>
+                        <p class="small text-muted mb-2">
+                            Allow the V2 contract to transfer your V1 Token #{{ submission.v1TokenId }}.
+                            This is required for migration.
+                        </p>
+
+                        <div id="approval-status" class="mb-3">
+                            <div id="approval-not-started">
+                                <span class="badge bg-warning text-dark">Not Approved</span>
+                            </div>
+                            <div id="approval-in-progress" style="display: none;">
+                                <span class="spinner-border spinner-border-sm" role="status"></span>
+                                <span class="ms-2">Approving...</span>
+                            </div>
+                            <div id="approval-complete" style="display: none;">
+                                <span class="badge bg-success">Approved</span>
+                            </div>
+                            <div id="approval-error" class="alert alert-danger mt-2" style="display: none;"></div>
                         </div>
-                        <button id="connect-wallet-btn" class="btn btn-primary">Connect Wallet</button>
+
+                        <button id="approve-btn" class="btn btn-outline-primary">
+                            Approve V2 Contract
+                        </button>
                     </div>
                 </div>
+                {% endif %}
 
-                <!-- Mint Action -->
+                <!-- Mint/Migrate Action -->
                 <div class="card semi-transparent-bg">
                     <div class="card-body">
-                        <h5 class="card-title">Mint Tokens</h5>
+                        {% if submission.isUpgrade %}
+                        <h5 class="card-title">4. Migrate to V2</h5>
+                        <p>This will migrate <strong>Token #{{ submission.v1TokenId }}</strong> from V1 to V2 with the following metadata:</p>
+                        <ul class="list-unstyled mb-3">
+                            <li class="mb-1"><strong>Song ID:</strong> <code>{{ submission.songId }}</code></li>
+                            <li class="mb-1"><strong>Block Height:</strong> <code>{{ submission.blockHeight }}</code></li>
+                        </ul>
+                        <p class="small text-muted">The V1 token will be burned (sent to dead address) and a V2 token with the same ID will be minted to you.</p>
+
+                        <div class="d-grid gap-2">
+                            <button id="mint-btn" class="btn btn-success btn-lg" disabled>
+                                Migrate Token #{{ submission.v1TokenId }} to V2
+                            </button>
+                        </div>
+                        {% else %}
+                        <h5 class="card-title">3. Mint Tokens</h5>
                         <p>This will mint <strong>{{ submission.participants | length }}</strong> token(s) to:</p>
                         <ul class="list-unstyled mb-3">
                             {% for participant in submission.participants %}
@@ -114,6 +198,7 @@
                                 Mint {{ submission.participants | length }} Token(s)
                             </button>
                         </div>
+                        {% endif %}
 
                         <!-- Status messages -->
                         <div id="status-area" class="mt-3" style="display: none;">
@@ -157,7 +242,7 @@ w3m-modal {
     document.addEventListener('DOMContentLoaded', function() {
         if (window.initMintPage) {
             window.initMintPage({
-                id: {{ submission.id }},
+                id: {{ submission.id | default(0) }},
                 songId: {{ submission.songId }},
                 blockHeight: {{ submission.blockHeight | default(0) }},
                 videoUrl: '{{ submission.videoUrl | default("", true) }}',
@@ -167,7 +252,10 @@ w3m-modal {
                     {% endfor %}
                 ],
                 pinningService: 'https://pinning.maybelle.cryptograss.live/pin-from-url',
-                pickipediaUrl: '{{ submission.url }}'
+                pickipediaUrl: '{{ submission.url | default("", true) }}',
+                // Upgrade-specific fields
+                isUpgrade: {{ 'true' if submission.isUpgrade else 'false' }},
+                v1TokenId: {{ submission.v1TokenId | default('null') }}
             });
         } else {
             console.error('mint-submission.js not loaded - initMintPage not found');

--- a/src/sites/cryptograss.live/templates/pages/blox-office/admin/mint-tony.njk
+++ b/src/sites/cryptograss.live/templates/pages/blox-office/admin/mint-tony.njk
@@ -4,7 +4,7 @@
 <div class="row">
     <div class="col-1"></div>
     <div class="col-md-10 text-post">
-        <h1 class="text-center pixel-font">Mint Blue Railroad Token</h1>
+        <h1 class="text-center pixel-font">Mint Blue Railroad Token (V2)</h1>
         <p class="text-center text-muted">Admin page for issuing Manzanita exercise challenge tokens</p>
 
         <div class="row mt-4">
@@ -48,92 +48,69 @@
                                 <label for="song-select" class="form-label">Exercise Challenge</label>
                                 <select class="form-select" id="song-select" required>
                                     <option value="">Select a song...</option>
-                                    <option value="5">Blue Railroad Train - Squats</option>
-                                    <option value="6">Nine Pound Hammer - Pushups</option>
-                                    <option value="10">Ginseng Sullivan - Army Crawls</option>
+                                    <option value="7">Blue Railroad Train - Squats (Track 7)</option>
+                                    <option value="5">Nine Pound Hammer - Pushups (Track 5)</option>
+                                    <option value="8">Ginseng Sullivan - Army Crawls (Track 8)</option>
                                 </select>
                                 <div class="form-text">Track number from Manzanita (1979)</div>
                             </div>
 
                             <div class="mb-3">
-                                <label for="date-input" class="form-label">Date Completed</label>
-                                <input type="date" class="form-control" id="date-input" required>
-                                <div class="form-text">When the exercise was performed</div>
+                                <label for="blockheight-input" class="form-label">Ethereum Block Height</label>
+                                <div class="input-group">
+                                    <input type="number" class="form-control" id="blockheight-input"
+                                           placeholder="e.g. 24207967" required>
+                                    <button type="button" class="btn btn-outline-secondary" id="fetch-block-btn">
+                                        Current Block
+                                    </button>
+                                </div>
+                                <div class="form-text">Mainnet block height when the exercise was performed</div>
+                                <div id="block-info" class="form-text text-info mt-1" style="display: none;"></div>
                             </div>
 
-                            <!-- Video Upload Section -->
+                            <!-- Video Hash Section -->
                             <div class="mb-3">
-                                <label class="form-label">Video Source</label>
+                                <label class="form-label">Video IPFS Hash</label>
                                 <ul class="nav nav-tabs" id="video-source-tabs" role="tablist">
                                     <li class="nav-item" role="presentation">
-                                        <button class="nav-link active" id="url-tab" data-bs-toggle="tab"
-                                                data-bs-target="#url-pane" type="button" role="tab">
-                                            From URL (Instagram, etc.)
+                                        <button class="nav-link active" id="cid-tab" data-bs-toggle="tab"
+                                                data-bs-target="#cid-pane" type="button" role="tab">
+                                            IPFS CID (Qm...)
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
-                                        <button class="nav-link" id="upload-tab" data-bs-toggle="tab"
-                                                data-bs-target="#upload-pane" type="button" role="tab">
-                                            Upload File
-                                        </button>
-                                    </li>
-                                    <li class="nav-item" role="presentation">
-                                        <button class="nav-link" id="manual-tab" data-bs-toggle="tab"
-                                                data-bs-target="#manual-pane" type="button" role="tab">
-                                            Manual URI
+                                        <button class="nav-link" id="bytes32-tab" data-bs-toggle="tab"
+                                                data-bs-target="#bytes32-pane" type="button" role="tab">
+                                            Raw bytes32
                                         </button>
                                     </li>
                                 </ul>
                                 <div class="tab-content border border-top-0 p-3" id="video-source-content">
-                                    <!-- URL Download Tab -->
-                                    <div class="tab-pane fade show active" id="url-pane" role="tabpanel">
-                                        <div class="input-group">
-                                            <input type="text" class="form-control" id="video-url"
-                                                   placeholder="https://www.instagram.com/p/...">
-                                            <button type="button" class="btn btn-outline-primary" id="fetch-video-btn">
-                                                Fetch & Pin
-                                            </button>
+                                    <!-- IPFS CID Tab -->
+                                    <div class="tab-pane fade show active" id="cid-pane" role="tabpanel">
+                                        <input type="text" class="form-control" id="ipfs-cid"
+                                               placeholder="QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG">
+                                        <div class="form-text">CIDv0 format (starts with Qm)</div>
+                                        <div id="cid-convert-status" class="mt-2" style="display: none;">
+                                            <div id="cid-success" class="alert alert-success py-2" style="display: none;">
+                                                <strong>Converted:</strong>
+                                                <code id="converted-hash" class="d-block mt-1" style="word-break: break-all;"></code>
+                                            </div>
+                                            <div id="cid-error" class="alert alert-danger py-2" style="display: none;"></div>
                                         </div>
-                                        <div class="form-text">Paste Instagram, YouTube, or other video URL</div>
                                     </div>
 
-                                    <!-- File Upload Tab -->
-                                    <div class="tab-pane fade" id="upload-pane" role="tabpanel">
-                                        <div class="input-group">
-                                            <input type="file" class="form-control" id="video-file"
-                                                   accept="video/*">
-                                            <button type="button" class="btn btn-outline-primary" id="upload-video-btn">
-                                                Upload & Pin
-                                            </button>
-                                        </div>
-                                        <div class="form-text">Select a video file (max 500MB)</div>
+                                    <!-- Raw bytes32 Tab -->
+                                    <div class="tab-pane fade" id="bytes32-pane" role="tabpanel">
+                                        <input type="text" class="form-control" id="raw-bytes32"
+                                               placeholder="0x...">
+                                        <div class="form-text">32-byte hex string (64 hex chars + 0x prefix)</div>
                                     </div>
-
-                                    <!-- Manual URI Tab -->
-                                    <div class="tab-pane fade" id="manual-pane" role="tabpanel">
-                                        <input type="text" class="form-control" id="manual-uri"
-                                               placeholder="ipfs://Qm... or https://...">
-                                        <div class="form-text">If you already have the IPFS CID or direct URL</div>
-                                    </div>
-                                </div>
-
-                                <!-- Pin Status -->
-                                <div id="pin-status" class="mt-2" style="display: none;">
-                                    <div id="pin-pending" class="alert alert-info py-2" style="display: none;">
-                                        <span class="spinner-border spinner-border-sm" role="status"></span>
-                                        <span id="pin-status-text">Downloading video...</span>
-                                    </div>
-                                    <div id="pin-success" class="alert alert-success py-2" style="display: none;">
-                                        <strong>Pinned!</strong>
-                                        <span id="pin-cid" class="font-monospace"></span>
-                                        <a id="pin-gateway-link" href="#" target="_blank" class="ms-2">View on IPFS</a>
-                                    </div>
-                                    <div id="pin-error" class="alert alert-danger py-2" style="display: none;"></div>
                                 </div>
                             </div>
 
-                            <!-- Hidden field for final URI -->
-                            <input type="hidden" id="video-uri" required>
+                            <!-- Hidden field for final bytes32 -->
+                            <input type="hidden" id="video-hash" required>
 
                             <div class="d-grid gap-2">
                                 <button type="submit" id="mint-btn" class="btn btn-success btn-lg" disabled>
@@ -160,18 +137,32 @@
                 <!-- Reference Info -->
                 <div class="card semi-transparent-bg mt-4">
                     <div class="card-body">
-                        <h6 class="card-title">Manzanita Tracklist Reference</h6>
+                        <h6 class="card-title">V2 Contract Info</h6>
+                        <dl class="row mb-2">
+                            <dt class="col-sm-3">Contract</dt>
+                            <dd class="col-sm-9">
+                                <a href="https://optimistic.etherscan.io/address/0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7"
+                                   target="_blank" class="font-monospace small">
+                                    0x7C3a...14B7
+                                </a>
+                            </dd>
+                            <dt class="col-sm-3">Network</dt>
+                            <dd class="col-sm-9">Optimism</dd>
+                            <dt class="col-sm-3">Token IDs</dt>
+                            <dd class="col-sm-9">New mints start at #5 (0-4 reserved for V1 migrations)</dd>
+                        </dl>
+                        <h6 class="card-title mt-3">Manzanita Tracklist Reference</h6>
                         <ol class="small mb-0">
-                            <li>Old Train</li>
+                            <li>Church Street Blues</li>
                             <li>Manzanita</li>
                             <li>Little Sadie</li>
                             <li>Blackberry Blossom</li>
-                            <li><strong>Blue Railroad Train</strong> (Squats)</li>
                             <li><strong>Nine Pound Hammer</strong> (Pushups)</li>
-                            <li>Red Haired Boy</li>
-                            <li>Streets of London</li>
-                            <li>Old Grey Coat</li>
+                            <li>Home from the Forest</li>
+                            <li><strong>Blue Railroad Train</strong> (Squats)</li>
                             <li><strong>Ginseng Sullivan</strong> (Army Crawls)</li>
+                            <li>Red Haired Boy</li>
+                            <li>Old Grey Coat</li>
                         </ol>
                     </div>
                 </div>
@@ -188,9 +179,7 @@
     font-weight: bold;
 }
 
-/* Override Web3Modal's z-index CSS variable
-   Note: #main-container has z-index: 1000 in global styles,
-   Web3Modal uses --w3m-z-index (default 999), so we need higher */
+/* Override Web3Modal's z-index CSS variable */
 :root {
     --w3m-z-index: 10000 !important;
 }
@@ -214,22 +203,139 @@ w3m-modal {
     import { WagmiAdapter } from 'https://cdn.jsdelivr.net/npm/@reown/appkit-adapter-wagmi@1.6.8/+esm';
     import { reconnect, getAccount, writeContract, waitForTransactionReceipt } from 'https://cdn.jsdelivr.net/npm/@wagmi/core@2.16.4/+esm';
 
-    console.log('[mint-tony] Imports loaded successfully');
+    console.log('[mint-tony-v2] Imports loaded successfully');
 
-    // Blue Railroad contract config
-    const BR_CONTRACT = '0xCe09A2d0d0BDE635722D8EF31901b430E651dB52';
+    // Blue Railroad V2 contract config
+    const BR_CONTRACT = '0x7C3aEBcD477C591EbCde3bC247B3A9531814B4B7';
     const BR_ABI = [{
         inputs: [
             { internalType: 'address', name: 'recipient', type: 'address' },
-            { internalType: 'uint32', name: 'songId', type: 'uint32' },
-            { internalType: 'uint32', name: 'date', type: 'uint32' },
-            { internalType: 'string', name: 'uri', type: 'string' }
+            { internalType: 'uint8', name: 'songId', type: 'uint8' },
+            { internalType: 'uint256', name: 'blockheight', type: 'uint256' },
+            { internalType: 'bytes32', name: 'videoHash', type: 'bytes32' }
         ],
         name: 'issueTony',
         outputs: [],
         stateMutability: 'nonpayable',
         type: 'function'
     }];
+
+    // Base58 alphabet for CIDv0 decoding
+    const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+    // Base32 alphabet for CIDv1 decoding (RFC 4648, lowercase)
+    const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+    function base58Decode(str) {
+        const bytes = [];
+        for (let i = 0; i < str.length; i++) {
+            const char = str[i];
+            const index = BASE58_ALPHABET.indexOf(char);
+            if (index === -1) throw new Error(`Invalid base58 character: ${char}`);
+
+            let carry = index;
+            for (let j = 0; j < bytes.length; j++) {
+                carry += bytes[j] * 58;
+                bytes[j] = carry & 0xff;
+                carry >>= 8;
+            }
+            while (carry > 0) {
+                bytes.push(carry & 0xff);
+                carry >>= 8;
+            }
+        }
+
+        for (let i = 0; i < str.length && str[i] === '1'; i++) {
+            bytes.push(0);
+        }
+
+        return new Uint8Array(bytes.reverse());
+    }
+
+    function base32Decode(str) {
+        str = str.replace(/=+$/, '').toLowerCase();
+
+        let bits = 0;
+        let value = 0;
+        const output = [];
+
+        for (let i = 0; i < str.length; i++) {
+            const char = str[i];
+            const index = BASE32_ALPHABET.indexOf(char);
+            if (index === -1) throw new Error(`Invalid base32 character: ${char}`);
+
+            value = (value << 5) | index;
+            bits += 5;
+
+            if (bits >= 8) {
+                output.push((value >>> (bits - 8)) & 0xff);
+                bits -= 8;
+            }
+        }
+
+        return new Uint8Array(output);
+    }
+
+    function readVarint(bytes, offset) {
+        let value = 0;
+        let shift = 0;
+        let bytesRead = 0;
+
+        while (offset + bytesRead < bytes.length) {
+            const byte = bytes[offset + bytesRead];
+            value |= (byte & 0x7f) << shift;
+            bytesRead++;
+            if ((byte & 0x80) === 0) break;
+            shift += 7;
+        }
+
+        return [value, bytesRead];
+    }
+
+    function cidToBytes32(cid) {
+        if (!cid) throw new Error('No CID provided');
+
+        if (cid.startsWith('0x')) {
+            if (cid.length === 66) return cid;
+            throw new Error('Invalid bytes32 hex string');
+        }
+
+        let hashBytes;
+
+        if (cid.startsWith('Qm')) {
+            const decoded = base58Decode(cid);
+            if (decoded.length !== 34) throw new Error(`Invalid CIDv0 length: ${decoded.length}`);
+            if (decoded[0] !== 0x12 || decoded[1] !== 0x20) throw new Error('Invalid CIDv0 multihash prefix');
+            hashBytes = decoded.slice(2);
+        }
+        else if (cid.startsWith('b')) {
+            const decoded = base32Decode(cid.slice(1));
+            let offset = 0;
+
+            const [version, vBytes] = readVarint(decoded, offset);
+            offset += vBytes;
+            if (version !== 1) throw new Error(`Unexpected CID version: ${version}`);
+
+            const [codec, cBytes] = readVarint(decoded, offset);
+            offset += cBytes;
+
+            const [hashFn, hBytes] = readVarint(decoded, offset);
+            offset += hBytes;
+            if (hashFn !== 0x12) throw new Error(`Unsupported hash function: 0x${hashFn.toString(16)}`);
+
+            const [digestLen, dBytes] = readVarint(decoded, offset);
+            offset += dBytes;
+            if (digestLen !== 32) throw new Error(`Unexpected digest length: ${digestLen}`);
+
+            hashBytes = decoded.slice(offset, offset + 32);
+            if (hashBytes.length !== 32) throw new Error('Could not extract hash from CIDv1');
+        }
+        else {
+            throw new Error('Unsupported CID format. Expected Qm... or b...');
+        }
+
+        return '0x' + Array.from(hashBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+    }
 
     // Setup Web3Modal
     const projectId = 'c4f79cc821d56e59de850c9b35cbbe86';
@@ -263,9 +369,16 @@ w3m-modal {
     const mintBtn = document.getElementById('mint-btn');
     const mintForm = document.getElementById('mint-form');
     const songSelect = document.getElementById('song-select');
-    const dateInput = document.getElementById('date-input');
-    const videoUri = document.getElementById('video-uri');
-    const manualUri = document.getElementById('manual-uri');
+    const blockheightInput = document.getElementById('blockheight-input');
+    const fetchBlockBtn = document.getElementById('fetch-block-btn');
+    const blockInfo = document.getElementById('block-info');
+    const ipfsCid = document.getElementById('ipfs-cid');
+    const rawBytes32 = document.getElementById('raw-bytes32');
+    const videoHash = document.getElementById('video-hash');
+    const cidConvertStatus = document.getElementById('cid-convert-status');
+    const cidSuccess = document.getElementById('cid-success');
+    const cidError = document.getElementById('cid-error');
+    const convertedHash = document.getElementById('converted-hash');
     const recipientsContainer = document.getElementById('recipients-container');
     const addRecipientBtn = document.getElementById('add-recipient-btn');
     const statusArea = document.getElementById('status-area');
@@ -278,50 +391,105 @@ w3m-modal {
 
     // Parse query parameters on load
     function initFromQueryParams() {
-        console.log('[mint-tony] initFromQueryParams called');
-        console.log('[mint-tony] search:', window.location.search);
         const params = new URLSearchParams(window.location.search);
 
-        // Pre-select song if provided
         const songParam = params.get('song');
-        console.log('[mint-tony] songParam:', songParam);
         if (songParam) {
-            console.log('[mint-tony] Setting song to:', songParam);
             songSelect.value = songParam;
-            console.log('[mint-tony] songSelect.value is now:', songSelect.value);
         }
 
-        // Pre-fill recipients if provided (comma-separated)
         const recipientsParam = params.get('recipients');
         if (recipientsParam) {
             const recipients = recipientsParam.split(',').map(r => r.trim()).filter(r => r);
             if (recipients.length > 0) {
-                // Fill first recipient
                 const firstInput = recipientsContainer.querySelector('.recipient-input');
                 firstInput.value = recipients[0];
-
-                // Add additional recipients
                 for (let i = 1; i < recipients.length; i++) {
                     addRecipientRow(recipients[i]);
                 }
             }
         }
 
-        // Pre-fill date if provided
-        const dateParam = params.get('date');
-        if (dateParam) {
-            dateInput.value = dateParam;
+        const blockParam = params.get('block') || params.get('blockheight');
+        if (blockParam) {
+            blockheightInput.value = blockParam;
         }
 
-        // Pre-fill video URI if provided
-        const uriParam = params.get('uri');
-        if (uriParam) {
-            manualUri.value = uriParam;
-            videoUri.value = uriParam;
-            // Switch to manual tab
-            document.getElementById('manual-tab').click();
+        const cidParam = params.get('cid') || params.get('ipfs');
+        if (cidParam) {
+            ipfsCid.value = cidParam;
+            convertCidToBytes32();
+        }
+
+        const hashParam = params.get('hash') || params.get('videoHash');
+        if (hashParam) {
+            rawBytes32.value = hashParam;
+            videoHash.value = hashParam;
+            document.getElementById('bytes32-tab').click();
         }
     }
+
+    // Fetch current Ethereum block
+    async function fetchCurrentBlock() {
+        fetchBlockBtn.disabled = true;
+        fetchBlockBtn.textContent = 'Fetching...';
+
+        try {
+            const response = await fetch('https://eth.blockscout.com/api/v2/blocks?type=block');
+            const data = await response.json();
+            const currentBlock = data.items[0].height;
+            blockheightInput.value = currentBlock;
+            blockInfo.textContent = `Current mainnet block: ${currentBlock}`;
+            blockInfo.style.display = 'block';
+        } catch (err) {
+            console.error('Failed to fetch block:', err);
+            blockInfo.textContent = 'Failed to fetch current block';
+            blockInfo.className = 'form-text text-danger mt-1';
+            blockInfo.style.display = 'block';
+        } finally {
+            fetchBlockBtn.disabled = false;
+            fetchBlockBtn.textContent = 'Current Block';
+        }
+    }
+
+    fetchBlockBtn.addEventListener('click', fetchCurrentBlock);
+
+    // Convert CID to bytes32
+    function convertCidToBytes32() {
+        const cid = ipfsCid.value.trim();
+        if (!cid) {
+            cidConvertStatus.style.display = 'none';
+            videoHash.value = '';
+            return;
+        }
+
+        cidConvertStatus.style.display = 'block';
+
+        try {
+            const hash = cidToBytes32(cid);
+            videoHash.value = hash;
+            convertedHash.textContent = hash;
+            cidSuccess.style.display = 'block';
+            cidError.style.display = 'none';
+        } catch (err) {
+            videoHash.value = '';
+            cidError.textContent = err.message;
+            cidError.style.display = 'block';
+            cidSuccess.style.display = 'none';
+        }
+    }
+
+    ipfsCid.addEventListener('input', convertCidToBytes32);
+
+    // Raw bytes32 input
+    rawBytes32.addEventListener('input', () => {
+        const value = rawBytes32.value.trim();
+        if (value.match(/^0x[a-fA-F0-9]{64}$/)) {
+            videoHash.value = value;
+        } else {
+            videoHash.value = '';
+        }
+    });
 
     // Multi-recipient management
     function addRecipientRow(value = '') {
@@ -339,9 +507,8 @@ w3m-modal {
 
     function updateRemoveButtons() {
         const rows = recipientsContainer.querySelectorAll('.recipient-row');
-        rows.forEach((row, index) => {
+        rows.forEach((row) => {
             const removeBtn = row.querySelector('.remove-recipient');
-            // Show remove button only if there's more than one recipient
             removeBtn.style.display = rows.length > 1 ? 'block' : 'none';
         });
     }
@@ -381,25 +548,10 @@ w3m-modal {
         modal.open();
     });
 
-    // Watch for account changes
     wagmiAdapter.wagmiConfig.subscribe(
         (state) => state.current,
         () => updateWalletUI()
     );
-
-    // Manual URI updates video-uri hidden field
-    manualUri.addEventListener('input', () => {
-        videoUri.value = manualUri.value;
-    });
-
-    // Convert date string to uint32 (YYYYMMDD format)
-    function dateToUint32(dateStr) {
-        const date = new Date(dateStr);
-        const year = date.getFullYear();
-        const month = String(date.getMonth() + 1).padStart(2, '0');
-        const day = String(date.getDate()).padStart(2, '0');
-        return parseInt(`${year}${month}${day}`, 10);
-    }
 
     // Mint form submission
     mintForm.addEventListener('submit', async (e) => {
@@ -407,8 +559,8 @@ w3m-modal {
 
         const recipients = getRecipients();
         const songId = parseInt(songSelect.value, 10);
-        const date = dateToUint32(dateInput.value);
-        const uri = videoUri.value || manualUri.value;
+        const blockheight = BigInt(blockheightInput.value);
+        const hash = videoHash.value;
 
         if (recipients.length === 0) {
             showError('Please enter at least one recipient');
@@ -420,8 +572,13 @@ w3m-modal {
             return;
         }
 
-        if (!uri) {
-            showError('Please provide a video URI');
+        if (!blockheight) {
+            showError('Please enter a block height');
+            return;
+        }
+
+        if (!hash || !hash.match(/^0x[a-fA-F0-9]{64}$/)) {
+            showError('Please provide a valid video hash (bytes32)');
             return;
         }
 
@@ -438,22 +595,22 @@ w3m-modal {
                 const recipient = recipients[i];
                 pendingText.textContent = `Minting token ${i + 1} of ${recipients.length} for ${recipient}...`;
 
-                const hash = await writeContract(wagmiConfig, {
+                const txHash = await writeContract(wagmiConfig, {
                     address: BR_CONTRACT,
                     abi: BR_ABI,
                     functionName: 'issueTony',
-                    args: [recipient, songId, date, uri],
+                    args: [recipient, songId, blockheight, hash],
                     chainId: 10 // Optimism
                 });
 
                 pendingText.textContent = `Waiting for confirmation (${i + 1}/${recipients.length})...`;
 
-                const receipt = await waitForTransactionReceipt(wagmiConfig, {
-                    hash,
+                await waitForTransactionReceipt(wagmiConfig, {
+                    hash: txHash,
                     chainId: 10
                 });
 
-                txResults.push({ recipient, hash, success: true });
+                txResults.push({ recipient, hash: txHash, success: true });
             }
 
             // All successful
@@ -470,7 +627,6 @@ w3m-modal {
             pendingMsg.style.display = 'none';
 
             if (txResults.length > 0) {
-                // Partial success
                 successMsg.style.display = 'block';
                 successText.textContent = `Minted ${txResults.length} token${txResults.length > 1 ? 's' : ''} before error:`;
                 txLinks.innerHTML = txResults.map(r =>

--- a/src/sites/cryptograss.live/templates/pages/blox-office/admin/pending-submissions.njk
+++ b/src/sites/cryptograss.live/templates/pages/blox-office/admin/pending-submissions.njk
@@ -52,7 +52,7 @@
                                             {% endif %}
                                         </td>
                                         <td>
-                                            <a href="/blox-office/admin/mint/{{ submission.id }}"
+                                            <a href="/blox-office/admin/mint/bluerailroad/from-pickipedia/{{ submission.id }}"
                                                class="btn btn-primary btn-sm">
                                                 Mint
                                             </a>


### PR DESCRIPTION
## Summary
- Add `BlueRailroadV2` entry to `enumerable_contracts.json` with address `0x40b23771DAf0D89dE153a70a9F57741a96ed1Dd1`
- Add the `getBlueRailroadV2s()` call in `fetch_chaindata()` — the function existed on main (from PR #347) but the call was only on production, lost during merge

Currently 1 V2 token (ID 0, song 7, owned by Justin).

## Note on token ID 0
The V2 contract's `_nextTokenId` wasn't initialized to 5 in the constructor, so the first `issueTony` minted at ID 0 instead of 5. V1 token #0 migration would need that V2 token burned first.

## Test plan
- [x] `npm run fetch-chain-data` locally — V2 token appears in chainData.json with correct ownerDisplay