### PR TITLE
Fix EPK webpack path

### DIFF
--- a/src/build_logic/webpack.justinholmes.common.js
+++ b/src/build_logic/webpack.justinholmes.common.js
@@ -85,9 +85,9 @@ export default {
                 // EPK - standalone site for epk.justinholmes.com
                 // Goes to output/dist/epk (sibling to output/dist/justinholmes.com)
                 {
-                    from: path.resolve(srcDir, '../../epk'),
+                    from: path.resolve(srcDir, '../epk'),
                     to: path.resolve(outputDistDir, '../epk'),
-                    noErrorOnMissing: true
+                    noErrorOnMissing: false
                 },
             ]
         }),


### PR DESCRIPTION
## Fix

The EPK copy path was wrong:
- `srcDir` = `src/`
- `../../epk` from `src/` goes to parent of project root (wrong)
- `../epk` from `src/` goes to project root where `epk/` lives (correct)

Also set `noErrorOnMissing: false` so we catch path errors in the future.