### PR TITLE
Fix EPK: add toType dir

### DIFF
--- a/src/build_logic/webpack.justinholmes.common.js
+++ b/src/build_logic/webpack.justinholmes.common.js
@@ -86,6 +86,7 @@ export default {
                 {
                     from: path.resolve(srcDir, '../epk'),
                     to: path.resolve(outputDistDir, '../epk.justinholmes.com'),
+                    toType: 'dir',
                     noErrorOnMissing: false
                 },
             ]


### PR DESCRIPTION
CopyPlugin needs toType: 'dir' to create a directory instead of a file