### PR TITLE
Refactor album upload to multi-step workflow

### DIFF
--- a/src/sites/cryptograss.live/js/upload-album.js
+++ b/src/sites/cryptograss.live/js/upload-album.js
@@ -1,6 +1,10 @@
 /**
- * Album Upload Page
- * Handles wallet connection, metadata entry, multi-file upload with transcoding
+ * Album Upload Page - Multi-Step Workflow
+ *
+ * Step 1: Connect wallet
+ * Step 2: Upload files → creates draft, server analyzes
+ * Step 3: Review & edit track titles, album info
+ * Step 4: Finalize → transcode, pin to IPFS
  */
 
 import { reconnect, getAccount, signMessage } from '@wagmi/core';
@@ -14,16 +18,18 @@ const wallet = createWalletConnection({
 
 const { modal, wagmiAdapter, wagmiConfig } = wallet || {};
 
+// Local storage key for draft recovery
+const DRAFT_STORAGE_KEY = 'cryptograss-album-draft';
+
 export function initUploadAlbumPage(options) {
     const { pinningService, gateway } = options;
 
     // Check if wallet connection was successfully initialized
     if (!wallet) {
         console.error('[Upload] Wallet connection failed to initialize');
-        console.error('[Upload] Check earlier [Reown] errors in console for details');
         const errorDiv = document.getElementById('upload-error');
         if (errorDiv) {
-            errorDiv.textContent = 'Wallet connection failed to initialize. Check console for details (likely domain not whitelisted in Reown Cloud).';
+            errorDiv.textContent = 'Wallet connection failed to initialize. Check console for details.';
             errorDiv.style.display = 'block';
         }
         return;
@@ -42,41 +48,87 @@ export function initUploadAlbumPage(options) {
     }
 
     // State
-    let selectedFiles = [];
-    let trackData = []; // { file, title, trackNumber }
+    let currentStep = 1;
+    let draftId = null;
+    let draftExpiresAt = null;
+    let trackData = []; // From server analysis: { original_filename, detected_title, format, duration_seconds, ... }
 
-    // DOM elements
+    // DOM Elements - Steps
+    const step1 = document.getElementById('step-1-wallet');
+    const step2 = document.getElementById('step-2-upload');
+    const step3 = document.getElementById('step-3-review');
+    const step4 = document.getElementById('step-4-finalize');
+    const resultSection = document.getElementById('result-section');
+
+    // DOM Elements - Step indicators
+    const stepIndicators = document.querySelectorAll('.step');
+
+    // DOM Elements - Wallet
     const connectBtn = document.getElementById('connect-wallet-btn');
     const notConnectedMsg = document.getElementById('not-connected-msg');
     const connectedAddress = document.getElementById('connected-address');
     const authorizationStatus = document.getElementById('authorization-status');
 
-    const albumTitle = document.getElementById('album-title');
-    const albumArtist = document.getElementById('album-artist');
-    const albumVersion = document.getElementById('album-version');
-    const albumYear = document.getElementById('album-year');
-    const albumDescription = document.getElementById('album-description');
-
+    // DOM Elements - Upload
     const uploadArea = document.getElementById('upload-area');
     const fileInput = document.getElementById('file-input');
     const browseLink = document.getElementById('browse-link');
-    const trackListSection = document.getElementById('track-list-section');
-    const trackList = document.getElementById('track-list');
-    const uploadBtn = document.getElementById('upload-btn');
-
     const uploadProgress = document.getElementById('upload-progress');
     const uploadProgressText = document.getElementById('upload-progress-text');
     const uploadProgressBar = document.getElementById('upload-progress-bar');
-    const progressDetails = document.getElementById('progress-details');
     const uploadError = document.getElementById('upload-error');
 
-    const resultSection = document.getElementById('result-section');
+    // DOM Elements - Review
+    const albumTitle = document.getElementById('album-title');
+    const albumArtist = document.getElementById('album-artist');
+    const albumYear = document.getElementById('album-year');
+    const albumDescription = document.getElementById('album-description');
+    const trackList = document.getElementById('track-list');
+    const draftIdDisplay = document.getElementById('draft-id-display');
+    const draftExpiresDisplay = document.getElementById('draft-expires-display');
+    const draftInfo = document.getElementById('draft-info');
+    const backToUploadBtn = document.getElementById('back-to-upload-btn');
+    const finalizeBtn = document.getElementById('finalize-btn');
+
+    // DOM Elements - Finalize
+    const finalizeProgress = document.getElementById('finalize-progress');
+    const finalizeProgressText = document.getElementById('finalize-progress-text');
+    const finalizeProgressBar = document.getElementById('finalize-progress-bar');
+    const finalizeDetails = document.getElementById('finalize-details');
+    const finalizeError = document.getElementById('finalize-error');
+
+    // DOM Elements - Result
     const resultCid = document.getElementById('result-cid');
     const copyCidBtn = document.getElementById('copy-cid-btn');
     const gatewayLink = document.getElementById('gateway-link');
     const resultTrackList = document.getElementById('result-track-list');
     const uploadDetails = document.getElementById('upload-details');
     const uploadAnotherBtn = document.getElementById('upload-another-btn');
+
+    // Step management
+    function setStep(step) {
+        currentStep = step;
+
+        // Hide all step containers
+        [step1, step2, step3, step4].forEach(el => el.style.display = 'none');
+
+        // Show current step
+        const stepMap = { 1: step1, 2: step2, 3: step3, 4: step4 };
+        if (stepMap[step]) {
+            stepMap[step].style.display = 'block';
+        }
+
+        // Update step indicators
+        stepIndicators.forEach(indicator => {
+            const indicatorStep = parseInt(indicator.dataset.step);
+            indicator.classList.remove('active', 'completed');
+            if (indicatorStep < step) {
+                indicator.classList.add('completed');
+            } else if (indicatorStep === step) {
+                indicator.classList.add('active');
+            }
+        });
+    }
 
     // Update wallet UI
     async function updateWalletUI() {
@@ -88,24 +140,33 @@ export function initUploadAlbumPage(options) {
             connectBtn.textContent = 'Connected';
 
             authorizationStatus.style.display = 'block';
-            authorizationStatus.textContent = 'Wallet connected. Authorization will be verified on upload.';
+            authorizationStatus.textContent = 'Wallet connected. Ready to upload.';
             authorizationStatus.className = 'small mt-2 authorized';
-            updateUploadButton();
+
+            // Auto-advance to upload step if on step 1
+            if (currentStep === 1) {
+                setStep(2);
+            }
         } else {
             notConnectedMsg.style.display = 'block';
             connectedAddress.style.display = 'none';
             authorizationStatus.style.display = 'none';
             connectBtn.textContent = 'Connect Wallet';
-            updateUploadButton();
+
+            // Go back to step 1 if wallet disconnects
+            if (currentStep > 1) {
+                setStep(1);
+            }
         }
+        updateFinalizeButton();
     }
 
-    function updateUploadButton() {
+    function updateFinalizeButton() {
         const account = getAccount(wagmiConfig);
         const hasFiles = trackData.length > 0;
         const hasTitle = albumTitle.value.trim().length > 0;
         const hasArtist = albumArtist.value.trim().length > 0;
-        uploadBtn.disabled = !account.address || !hasFiles || !hasTitle || !hasArtist;
+        finalizeBtn.disabled = !account.address || !hasFiles || !hasTitle || !hasArtist;
     }
 
     // Connect wallet
@@ -119,13 +180,11 @@ export function initUploadAlbumPage(options) {
             (state) => state.current,
             () => updateWalletUI()
         );
-    } else {
-        console.error('[Upload] Cannot subscribe to wallet changes - wagmiAdapter not initialized');
     }
 
     // Update button state on metadata changes
     [albumTitle, albumArtist].forEach(el => {
-        el.addEventListener('input', updateUploadButton);
+        el.addEventListener('input', updateFinalizeButton);
     });
 
     // File selection via browse link
@@ -142,9 +201,9 @@ export function initUploadAlbumPage(options) {
     });
 
     // File input change
-    fileInput.addEventListener('change', (e) => {
+    fileInput.addEventListener('change', async (e) => {
         if (e.target.files.length > 0) {
-            addFiles(Array.from(e.target.files));
+            await handleFileUpload(Array.from(e.target.files));
         }
     });
 
@@ -158,51 +217,129 @@ export function initUploadAlbumPage(options) {
         uploadArea.classList.remove('dragover');
     });
 
-    uploadArea.addEventListener('drop', (e) => {
+    uploadArea.addEventListener('drop', async (e) => {
         e.preventDefault();
         uploadArea.classList.remove('dragover');
         if (e.dataTransfer.files.length > 0) {
-            addFiles(Array.from(e.dataTransfer.files));
+            await handleFileUpload(Array.from(e.dataTransfer.files));
         }
     });
 
-    function addFiles(files) {
-        // Filter to audio files
-        const audioFiles = files.filter(f =>
-            /\.(flac|wav|mp3|ogg|m4a)$/i.test(f.name)
-        );
-
-        if (audioFiles.length === 0) {
-            uploadError.textContent = 'No supported audio files found. Use FLAC, WAV, MP3, OGG, or M4A.';
+    async function handleFileUpload(files) {
+        const account = getAccount(wagmiConfig);
+        if (!account.address) {
+            uploadError.textContent = 'Please connect your wallet first.';
             uploadError.style.display = 'block';
             return;
         }
 
         uploadError.style.display = 'none';
+        uploadProgress.style.display = 'block';
+        uploadProgressText.textContent = 'Signing authorization...';
+        uploadProgressBar.style.width = '0%';
 
-        // Sort by filename to get natural track order
-        audioFiles.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+        try {
+            // Get server time and sign authorization
+            let timestamp;
+            try {
+                const timeResp = await fetch(`${pinningService}/time`);
+                const timeData = await timeResp.json();
+                timestamp = timeData.time ?? timeData.timestamp ?? Date.now();
+            } catch (e) {
+                timestamp = Date.now();
+            }
 
-        // Create track data
-        trackData = audioFiles.map((file, index) => ({
-            file,
-            title: extractTrackTitle(file.name),
-            trackNumber: index + 1
-        }));
+            const authMessage = `Authorize Blue Railroad pinning\nTimestamp: ${timestamp}`;
+            const signature = await signMessage(wagmiConfig, { message: authMessage });
 
-        renderTrackList();
-        trackListSection.style.display = 'block';
-        updateUploadButton();
+            uploadProgressText.textContent = 'Uploading and analyzing files...';
+            uploadProgressBar.style.width = '20%';
+
+            // Build form data
+            const formData = new FormData();
+            files.forEach(file => {
+                formData.append('files', file);
+            });
+
+            // Send to draft endpoint
+            const response = await fetch(`${pinningService}/draft-album`, {
+                method: 'POST',
+                headers: {
+                    'X-Signature': signature,
+                    'X-Timestamp': timestamp.toString()
+                },
+                body: formData
+            });
+
+            if (!response.ok) {
+                const errData = await response.json().catch(() => ({}));
+                throw new Error(errData.detail || `HTTP ${response.status}`);
+            }
+
+            const result = await response.json();
+
+            // Store draft info
+            draftId = result.draft_id;
+            draftExpiresAt = result.expires_at;
+            trackData = result.files.map(f => ({
+                ...f,
+                title: f.detected_title // User-editable title
+            }));
+
+            // Save to localStorage for recovery
+            saveDraftToStorage();
+
+            uploadProgress.style.display = 'none';
+
+            // Move to review step
+            renderTrackList();
+            showDraftInfo();
+            setStep(3);
+
+        } catch (err) {
+            console.error('[Upload] Error:', err);
+            uploadProgress.style.display = 'none';
+            uploadError.textContent = err?.message || 'Upload failed';
+            uploadError.style.display = 'block';
+        }
     }
 
-    function extractTrackTitle(filename) {
-        // Remove extension
-        let name = filename.replace(/\.(flac|wav|mp3|ogg|m4a)$/i, '');
-        // Remove common prefixes like "01 - " or "01. "
-        name = name.replace(/^\d+[\s._-]+/, '');
-        // Replace underscores with spaces
-        name = name.replace(/_/g, ' ');
-        return name.trim() || filename;
+    function saveDraftToStorage() {
+        const data = {
+            draftId,
+            draftExpiresAt,
+            trackData,
+            albumTitle: albumTitle.value,
+            albumArtist: albumArtist.value,
+            albumYear: albumYear.value,
+            albumDescription: albumDescription.value
+        };
+        localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(data));
+    }
+
+    function loadDraftFromStorage() {
+        try {
+            const stored = localStorage.getItem(DRAFT_STORAGE_KEY);
+            if (!stored) return null;
+            return JSON.parse(stored);
+        } catch {
+            return null;
+        }
+    }
+
+    function clearDraftStorage() {
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
+    }
+
+    function showDraftInfo() {
+        if (draftId) {
+            draftIdDisplay.textContent = draftId.substring(0, 8) + '...';
+            if (draftExpiresAt) {
+                const expires = new Date(draftExpiresAt);
+                draftExpiresDisplay.textContent = expires.toLocaleString();
+            }
+            draftInfo.style.display = 'block';
+        }
     }
 
     function renderTrackList() {
@@ -213,19 +350,21 @@ export function initUploadAlbumPage(options) {
             tr.dataset.index = index;
 
             tr.innerHTML = `
-                <td class="text-muted">${track.trackNumber}</td>
+                <td class="text-muted">${index + 1}</td>
                 <td>
                     <span class="track-title" contenteditable="true" data-index="${index}">${escapeHtml(track.title)}</span>
                 </td>
-                <td class="small text-muted">${truncateFilename(track.file.name, 15)}</td>
-                <td class="small text-muted">${formatFileSize(track.file.size)}</td>
+                <td class="small text-muted">${track.format}</td>
+                <td class="small text-muted">${formatDuration(track.duration_seconds)}</td>
+                <td class="small text-muted">${formatFileSize(track.size_bytes)}</td>
             `;
 
             // Track title editing
             const titleSpan = tr.querySelector('.track-title');
             titleSpan.addEventListener('blur', (e) => {
                 const idx = parseInt(e.target.dataset.index);
-                trackData[idx].title = e.target.textContent.trim() || trackData[idx].file.name;
+                trackData[idx].title = e.target.textContent.trim() || trackData[idx].detected_title;
+                saveDraftToStorage();
             });
             titleSpan.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter') {
@@ -242,6 +381,7 @@ export function initUploadAlbumPage(options) {
 
             trackList.appendChild(tr);
         });
+        updateFinalizeButton();
     }
 
     let dragSrcIndex = null;
@@ -261,12 +401,10 @@ export function initUploadAlbumPage(options) {
         e.preventDefault();
         const targetIndex = parseInt(e.target.closest('tr').dataset.index);
         if (dragSrcIndex !== null && dragSrcIndex !== targetIndex) {
-            // Reorder
             const [moved] = trackData.splice(dragSrcIndex, 1);
             trackData.splice(targetIndex, 0, moved);
-            // Renumber
-            trackData.forEach((t, i) => t.trackNumber = i + 1);
             renderTrackList();
+            saveDraftToStorage();
         }
     }
 
@@ -275,125 +413,78 @@ export function initUploadAlbumPage(options) {
         dragSrcIndex = null;
     }
 
-    function escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    }
+    // Back to upload button
+    backToUploadBtn.addEventListener('click', () => {
+        setStep(2);
+    });
 
-    function truncateFilename(name, maxLen) {
-        if (name.length <= maxLen) return name;
-        const ext = name.split('.').pop();
-        const base = name.slice(0, -(ext.length + 1));
-        const truncated = base.slice(0, maxLen - ext.length - 4) + '...';
-        return truncated + '.' + ext;
-    }
-
-    function formatFileSize(bytes) {
-        if (bytes < 1024) return bytes + ' B';
-        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-        if (bytes < 1024 * 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + ' MB';
-        return (bytes / 1024 / 1024 / 1024).toFixed(2) + ' GB';
-    }
-
-    // Upload button click
-    uploadBtn.addEventListener('click', async () => {
-        console.log('[Upload] Upload button clicked');
-        console.log('[Upload] wagmiConfig exists:', !!wagmiConfig);
-
-        if (!wagmiConfig) {
-            console.error('[Upload] wagmiConfig is undefined - wallet not properly initialized');
-            uploadError.textContent = 'Wallet not properly initialized. Please refresh the page.';
-            uploadError.style.display = 'block';
+    // Finalize button click
+    finalizeBtn.addEventListener('click', async () => {
+        if (!draftId) {
+            finalizeError.textContent = 'No draft to finalize. Please upload files first.';
+            finalizeError.style.display = 'block';
             return;
         }
 
-        let account;
-        try {
-            account = getAccount(wagmiConfig);
-            console.log('[Upload] getAccount succeeded, address:', account?.address);
-        } catch (err) {
-            console.error('[Upload] getAccount failed:', err);
-            uploadError.textContent = 'Failed to get wallet account. Please reconnect.';
-            uploadError.style.display = 'block';
-            return;
-        }
-
+        const account = getAccount(wagmiConfig);
         if (!account.address) {
-            uploadError.textContent = 'Please connect your wallet first.';
-            uploadError.style.display = 'block';
+            finalizeError.textContent = 'Wallet disconnected. Please reconnect.';
+            finalizeError.style.display = 'block';
             return;
         }
 
-        if (trackData.length === 0) {
-            uploadError.textContent = 'Please add audio files first.';
-            uploadError.style.display = 'block';
-            return;
-        }
+        // Save current form values
+        saveDraftToStorage();
 
-        uploadBtn.disabled = true;
-        uploadError.style.display = 'none';
-        uploadProgress.style.display = 'block';
-        uploadProgressText.textContent = 'Signing authorization...';
-        uploadProgressBar.style.width = '0%';
-        progressDetails.textContent = '';
+        setStep(4);
+        finalizeError.style.display = 'none';
+        finalizeProgressText.textContent = 'Signing authorization...';
+        finalizeProgressBar.style.width = '0%';
+        finalizeDetails.textContent = '';
 
         try {
-            // Get server time
+            // Get server time and sign
             let timestamp;
             try {
                 const timeResp = await fetch(`${pinningService}/time`);
                 const timeData = await timeResp.json();
                 timestamp = timeData.time ?? timeData.timestamp ?? Date.now();
-                console.log('[Upload] Got server timestamp:', timestamp);
             } catch (e) {
-                console.warn('[Upload] Could not fetch server time, using local:', e);
                 timestamp = Date.now();
             }
 
-            // Create auth message and sign it
-            console.log('[Upload] Requesting signature...');
             const authMessage = `Authorize Blue Railroad pinning\nTimestamp: ${timestamp}`;
             const signature = await signMessage(wagmiConfig, { message: authMessage });
-            console.log('[Upload] Signature obtained');
 
-            uploadProgressText.textContent = 'Uploading files...';
-            uploadProgressBar.style.width = '5%';
+            finalizeProgressText.textContent = 'Starting finalization...';
+            finalizeProgressBar.style.width = '5%';
 
-            // Build form data
-            const formData = new FormData();
-            formData.append('title', albumTitle.value.trim());
-            formData.append('artist', albumArtist.value.trim());
-            formData.append('version', albumVersion.value.trim() || 'master');
-            formData.append('year', albumYear.value.trim() || new Date().getFullYear().toString());
-            formData.append('description', albumDescription.value.trim());
+            // Build finalize request
+            const requestBody = {
+                album_title: albumTitle.value.trim(),
+                artist: albumArtist.value.trim(),
+                year: albumYear.value.trim() || null,
+                description: albumDescription.value.trim() || null,
+                tracks: trackData.map(t => ({
+                    filename: t.original_filename,
+                    title: t.title
+                }))
+            };
 
-            // Add track metadata as JSON
-            const trackMeta = trackData.map(t => ({
-                trackNumber: t.trackNumber,
-                title: t.title,
-                filename: t.file.name
-            }));
-            formData.append('tracks', JSON.stringify(trackMeta));
-
-            // Add files
-            trackData.forEach((track, index) => {
-                formData.append('files', track.file);
-            });
-
-            // Use SSE for progress
-            const response = await fetch(`${pinningService}/pin-album-direct`, {
+            // Send finalize request (returns SSE stream)
+            const response = await fetch(`${pinningService}/draft-album/${draftId}/finalize`, {
                 method: 'POST',
                 headers: {
                     'X-Signature': signature,
-                    'X-Timestamp': timestamp.toString()
+                    'X-Timestamp': timestamp.toString(),
+                    'Content-Type': 'application/json'
                 },
-                body: formData
+                body: JSON.stringify(requestBody)
             });
 
             if (!response.ok) {
                 const errData = await response.json().catch(() => ({}));
-                throw new Error(errData.error || `HTTP ${response.status}`);
+                throw new Error(errData.detail || `HTTP ${response.status}`);
             }
 
             // Read SSE stream
@@ -408,60 +499,61 @@ export function initUploadAlbumPage(options) {
 
                 buffer += decoder.decode(value, { stream: true });
                 const lines = buffer.split('\n');
-                buffer = lines.pop(); // Keep incomplete line
+                buffer = lines.pop();
 
                 for (const line of lines) {
                     if (line.startsWith('data: ')) {
                         try {
                             const event = JSON.parse(line.slice(6));
-                            handleProgressEvent(event);
-                            if (event.stage === 'complete') {
+                            handleFinalizeEvent(event);
+                            if (event.cid) {
                                 finalResult = event;
                             }
                         } catch (e) {
                             console.warn('Failed to parse SSE event:', line);
                         }
+                    } else if (line.startsWith('event: error')) {
+                        // Next data line will have error
                     }
                 }
             }
 
             if (!finalResult) {
-                throw new Error('Upload completed without final result');
+                throw new Error('Finalization completed without result');
             }
 
+            // Clear draft storage on success
+            clearDraftStorage();
             showResult(finalResult);
 
         } catch (err) {
-            console.error('[Upload] Error during upload process');
-            console.error('[Upload] Error name:', err?.name);
-            console.error('[Upload] Error message:', err?.message);
-            console.error('[Upload] Full error:', err);
-            if (err?.stack) {
-                console.error('[Upload] Stack trace:', err.stack);
-            }
-            uploadProgress.style.display = 'none';
-            uploadError.textContent = err?.message || 'Upload failed';
-            uploadError.style.display = 'block';
-            uploadBtn.disabled = false;
+            console.error('[Finalize] Error:', err);
+            finalizeError.textContent = err?.message || 'Finalization failed';
+            finalizeError.style.display = 'block';
         }
     });
 
-    function handleProgressEvent(event) {
-        const { stage, message, progress, track } = event;
-
-        if (progress !== undefined) {
-            uploadProgressBar.style.width = progress + '%';
+    function handleFinalizeEvent(event) {
+        if (event.stage) {
+            finalizeProgressText.textContent = event.message || event.stage;
         }
-
-        uploadProgressText.textContent = message || stage;
-
-        if (track) {
-            progressDetails.textContent = `Processing: ${track}`;
+        if (event.progress !== undefined) {
+            finalizeProgressBar.style.width = event.progress + '%';
+        }
+        if (event.track) {
+            finalizeDetails.textContent = `Processing: ${event.track}`;
+        }
+        if (event.message && event.stage === 'error') {
+            finalizeError.textContent = event.message;
+            finalizeError.style.display = 'block';
         }
     }
 
     function showResult(result) {
-        uploadProgress.style.display = 'none';
+        // Hide finalize step
+        step4.style.display = 'none';
+
+        // Show result
         resultSection.style.display = 'block';
 
         resultCid.value = result.cid;
@@ -476,9 +568,9 @@ export function initUploadAlbumPage(options) {
                 const li = document.createElement('li');
                 li.className = 'list-group-item d-flex justify-content-between';
                 li.innerHTML = `
-                    <span>${track.trackNumber}. ${escapeHtml(track.title)}</span>
-                    <a href="${gateway}/${result.cid}/${track.filename}" target="_blank" class="text-muted">
-                        ${track.filename}
+                    <span>${track.track_number}. ${escapeHtml(track.title)}</span>
+                    <a href="${gateway}/${result.cid}/ogg/${track.track_number.toString().padStart(2, '0')}-${encodeURIComponent(track.title.replace(/[^a-zA-Z0-9 _-]/g, '').trim().substring(0, 50))}.ogg" target="_blank" class="text-muted">
+                        OGG
                     </a>
                 `;
                 resultTrackList.appendChild(li);
@@ -487,16 +579,21 @@ export function initUploadAlbumPage(options) {
 
         // Details
         let details = [];
-        if (result.totalSize) {
-            details.push(`Total: ${formatFileSize(result.totalSize)}`);
-        }
-        if (result.pinnedToPinata) {
+        if (result.pinata) {
             details.push('Pinned to Pinata');
         }
-        if (result.releasePageTitle) {
-            details.push(`Release: ${result.releasePageTitle}`);
+        if (result.album_title) {
+            details.push(`Album: ${result.album_title}`);
+        }
+        if (result.artist) {
+            details.push(`Artist: ${result.artist}`);
         }
         uploadDetails.textContent = details.join(' | ');
+
+        // Update step indicator to show completion
+        stepIndicators.forEach(indicator => {
+            indicator.classList.add('completed');
+        });
     }
 
     // Copy CID button
@@ -512,21 +609,116 @@ export function initUploadAlbumPage(options) {
     // Upload another button
     uploadAnotherBtn.addEventListener('click', () => {
         resultSection.style.display = 'none';
-        trackListSection.style.display = 'none';
+        draftId = null;
+        draftExpiresAt = null;
         trackData = [];
         trackList.innerHTML = '';
         fileInput.value = '';
         albumTitle.value = '';
         albumArtist.value = '';
-        albumVersion.value = '';
         albumYear.value = '';
         albumDescription.value = '';
-        uploadBtn.disabled = true;
-        updateUploadButton();
+        draftInfo.style.display = 'none';
+        clearDraftStorage();
+        setStep(2);
     });
+
+    // Utility functions
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function formatFileSize(bytes) {
+        if (bytes < 1024) return bytes + ' B';
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+        if (bytes < 1024 * 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+        return (bytes / 1024 / 1024 / 1024).toFixed(2) + ' GB';
+    }
+
+    function formatDuration(seconds) {
+        const mins = Math.floor(seconds / 60);
+        const secs = Math.floor(seconds % 60);
+        return `${mins}:${secs.toString().padStart(2, '0')}`;
+    }
+
+    // Check for existing draft on page load
+    async function checkForExistingDraft() {
+        const stored = loadDraftFromStorage();
+        if (!stored || !stored.draftId) return;
+
+        // Check if draft still exists on server
+        const account = getAccount(wagmiConfig);
+        if (!account.address) return;
+
+        try {
+            // Get auth
+            let timestamp;
+            try {
+                const timeResp = await fetch(`${pinningService}/time`);
+                const timeData = await timeResp.json();
+                timestamp = timeData.time ?? timeData.timestamp ?? Date.now();
+            } catch (e) {
+                timestamp = Date.now();
+            }
+
+            const authMessage = `Authorize Blue Railroad pinning\nTimestamp: ${timestamp}`;
+            const signature = await signMessage(wagmiConfig, { message: authMessage });
+
+            const response = await fetch(`${pinningService}/draft-album/${stored.draftId}`, {
+                headers: {
+                    'X-Signature': signature,
+                    'X-Timestamp': timestamp.toString()
+                }
+            });
+
+            if (response.ok) {
+                // Restore draft state
+                const serverDraft = await response.json();
+                draftId = stored.draftId;
+                draftExpiresAt = serverDraft.expires_at;
+                trackData = serverDraft.files.map((f, i) => ({
+                    ...f,
+                    title: stored.trackData?.[i]?.title || f.detected_title
+                }));
+
+                // Restore form values
+                if (stored.albumTitle) albumTitle.value = stored.albumTitle;
+                if (stored.albumArtist) albumArtist.value = stored.albumArtist;
+                if (stored.albumYear) albumYear.value = stored.albumYear;
+                if (stored.albumDescription) albumDescription.value = stored.albumDescription;
+
+                renderTrackList();
+                showDraftInfo();
+                setStep(3);
+
+                console.log('[Upload] Restored draft from storage:', draftId);
+            } else {
+                // Draft expired or not found
+                clearDraftStorage();
+            }
+        } catch (e) {
+            console.warn('[Upload] Could not restore draft:', e);
+            clearDraftStorage();
+        }
+    }
 
     // Initial UI update
     updateWalletUI();
+
+    // Try to restore draft after wallet connects
+    if (wagmiAdapter && wagmiAdapter.wagmiConfig) {
+        wagmiAdapter.wagmiConfig.subscribe(
+            (state) => state.current,
+            () => {
+                const account = getAccount(wagmiConfig);
+                if (account.address && !draftId) {
+                    checkForExistingDraft();
+                }
+            }
+        );
+    }
 }
 
 // Make available globally

--- a/src/sites/cryptograss.live/js/upload-album.js
+++ b/src/sites/cryptograss.live/js/upload-album.js
@@ -308,7 +308,7 @@ export function initUploadAlbumPage(options) {
         const data = {
             draftId,
             draftExpiresAt,
-            trackData,
+            trackData,  // includes per-track tags
             albumTitle: albumTitle.value,
             albumArtist: albumArtist.value,
             albumYear: albumYear.value,
@@ -345,18 +345,44 @@ export function initUploadAlbumPage(options) {
     function renderTrackList() {
         trackList.innerHTML = '';
         trackData.forEach((track, index) => {
+            // Initialize tags if not present
+            if (!track.tags) track.tags = '';
+
+            // Main row
             const tr = document.createElement('tr');
             tr.draggable = true;
             tr.dataset.index = index;
+            tr.classList.add('track-row');
+
+            const hasTags = track.tags && track.tags.trim().length > 0;
 
             tr.innerHTML = `
                 <td class="text-muted">${index + 1}</td>
                 <td>
+                    <span class="track-expand-toggle" data-index="${index}" style="cursor: pointer; user-select: none;">
+                        <span class="expand-icon">${hasTags ? '▼' : '▶'}</span>
+                    </span>
                     <span class="track-title" contenteditable="true" data-index="${index}">${escapeHtml(track.title)}</span>
                 </td>
                 <td class="small text-muted">${track.format}</td>
                 <td class="small text-muted">${formatDuration(track.duration_seconds)}</td>
                 <td class="small text-muted">${formatFileSize(track.size_bytes)}</td>
+            `;
+
+            // Expandable tags row
+            const tagsTr = document.createElement('tr');
+            tagsTr.classList.add('track-tags-row');
+            tagsTr.dataset.index = index;
+            tagsTr.style.display = hasTags ? 'table-row' : 'none';
+
+            tagsTr.innerHTML = `
+                <td></td>
+                <td colspan="4" class="pb-3 pt-1">
+                    <textarea class="form-control form-control-sm font-monospace track-tags-input"
+                              data-index="${index}" rows="2"
+                              placeholder="COMPOSER=Bill Monroe&#10;COMMENT=Recorded live at...">${escapeHtml(track.tags)}</textarea>
+                    <div class="form-text small">One tag per line as KEY=VALUE</div>
+                </td>
             `;
 
             // Track title editing
@@ -373,6 +399,29 @@ export function initUploadAlbumPage(options) {
                 }
             });
 
+            // Expand/collapse toggle
+            const toggle = tr.querySelector('.track-expand-toggle');
+            toggle.addEventListener('click', () => {
+                const idx = parseInt(toggle.dataset.index);
+                const tagsRow = trackList.querySelector(`.track-tags-row[data-index="${idx}"]`);
+                const icon = toggle.querySelector('.expand-icon');
+                if (tagsRow.style.display === 'none') {
+                    tagsRow.style.display = 'table-row';
+                    icon.textContent = '▼';
+                } else {
+                    tagsRow.style.display = 'none';
+                    icon.textContent = '▶';
+                }
+            });
+
+            // Tags textarea change handler
+            const tagsInput = tagsTr.querySelector('.track-tags-input');
+            tagsInput.addEventListener('blur', (e) => {
+                const idx = parseInt(e.target.dataset.index);
+                trackData[idx].tags = e.target.value;
+                saveDraftToStorage();
+            });
+
             // Drag handlers
             tr.addEventListener('dragstart', handleDragStart);
             tr.addEventListener('dragover', handleDragOver);
@@ -380,6 +429,7 @@ export function initUploadAlbumPage(options) {
             tr.addEventListener('dragend', handleDragEnd);
 
             trackList.appendChild(tr);
+            trackList.appendChild(tagsTr);
         });
         updateFinalizeButton();
     }
@@ -459,7 +509,25 @@ export function initUploadAlbumPage(options) {
             finalizeProgressText.textContent = 'Starting finalization...';
             finalizeProgressBar.style.width = '5%';
 
-            // Build finalize request
+            // Helper to parse KEY=VALUE tags from a string
+            function parseTags(tagString) {
+                const tags = {};
+                if (!tagString) return null;
+                tagString.split('\n').forEach(line => {
+                    const trimmed = line.trim();
+                    if (trimmed && trimmed.includes('=')) {
+                        const eqIndex = trimmed.indexOf('=');
+                        const key = trimmed.substring(0, eqIndex).trim().toUpperCase();
+                        const value = trimmed.substring(eqIndex + 1).trim();
+                        if (key && value) {
+                            tags[key] = value;
+                        }
+                    }
+                });
+                return Object.keys(tags).length > 0 ? tags : null;
+            }
+
+            // Build finalize request with per-track tags
             const requestBody = {
                 album_title: albumTitle.value.trim(),
                 artist: albumArtist.value.trim(),
@@ -467,7 +535,8 @@ export function initUploadAlbumPage(options) {
                 description: albumDescription.value.trim() || null,
                 tracks: trackData.map(t => ({
                     filename: t.original_filename,
-                    title: t.title
+                    title: t.title,
+                    tags: parseTags(t.tags)
                 }))
             };
 
@@ -683,7 +752,7 @@ export function initUploadAlbumPage(options) {
                     title: stored.trackData?.[i]?.title || f.detected_title
                 }));
 
-                // Restore form values
+                // Restore form values (per-track tags are in trackData)
                 if (stored.albumTitle) albumTitle.value = stored.albumTitle;
                 if (stored.albumArtist) albumArtist.value = stored.albumArtist;
                 if (stored.albumYear) albumYear.value = stored.albumYear;

--- a/src/sites/cryptograss.live/templates/pages/tools/manage-pins.njk
+++ b/src/sites/cryptograss.live/templates/pages/tools/manage-pins.njk
@@ -1,0 +1,220 @@
+{% extends '../../base.njk' %}
+{% block main %}
+
+<div class="row">
+    <div class="col-1"></div>
+    <div class="col-md-10 text-post">
+        <h1 class="text-center pixel-font">Manage Pins</h1>
+        <p class="text-center text-muted">View and remove IPFS pins</p>
+
+        <!-- Wallet Connection -->
+        <div class="card semi-transparent-bg mb-4">
+            <div class="card-body">
+                <div id="not-connected">
+                    <p class="text-muted mb-2">Connect wallet to unpin items</p>
+                    <button id="connect-wallet-btn" class="btn btn-primary btn-sm">Connect Wallet</button>
+                </div>
+                <div id="connected" style="display: none;">
+                    <span class="text-muted">Connected:</span>
+                    <code id="wallet-address"></code>
+                </div>
+            </div>
+        </div>
+
+        <!-- Pins List -->
+        <div class="card semi-transparent-bg">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="card-title mb-0">Pinned Items</h5>
+                    <button id="refresh-btn" class="btn btn-outline-secondary btn-sm">Refresh</button>
+                </div>
+
+                <div id="loading" class="text-muted">Loading pins...</div>
+                <div id="error" class="text-danger" style="display: none;"></div>
+
+                <table class="table table-sm" id="pins-table" style="display: none;">
+                    <thead>
+                        <tr>
+                            <th>CID</th>
+                            <th style="width: 100px;"></th>
+                        </tr>
+                    </thead>
+                    <tbody id="pins-list"></tbody>
+                </table>
+
+                <div id="empty" class="text-muted" style="display: none;">No pins found</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-1"></div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+<script type="module">
+    import { reconnect, getAccount, signMessage } from '@wagmi/core';
+    import { createWalletConnection } from '/js/wallet-utils.js';
+
+    const pinningService = 'https://delivery-kid.cryptograss.live';
+    const gateway = 'https://ipfs.delivery-kid.cryptograss.live/ipfs';
+
+    const wallet = createWalletConnection({
+        name: 'Cryptograss Pin Manager',
+        description: 'Manage IPFS pins'
+    });
+
+    const { modal, wagmiConfig } = wallet || {};
+
+    // DOM elements
+    const connectBtn = document.getElementById('connect-wallet-btn');
+    const notConnected = document.getElementById('not-connected');
+    const connected = document.getElementById('connected');
+    const walletAddress = document.getElementById('wallet-address');
+    const refreshBtn = document.getElementById('refresh-btn');
+    const loading = document.getElementById('loading');
+    const error = document.getElementById('error');
+    const pinsTable = document.getElementById('pins-table');
+    const pinsList = document.getElementById('pins-list');
+    const empty = document.getElementById('empty');
+
+    let currentAddress = null;
+
+    // Wallet connection
+    if (wagmiConfig) {
+        reconnect(wagmiConfig).catch(() => {});
+
+        connectBtn.addEventListener('click', () => modal.open());
+
+        wagmiConfig.subscribe(
+            (state) => state,
+            (state) => {
+                const account = getAccount(wagmiConfig);
+                if (account.address) {
+                    currentAddress = account.address;
+                    walletAddress.textContent = account.address.slice(0, 6) + '...' + account.address.slice(-4);
+                    notConnected.style.display = 'none';
+                    connected.style.display = 'block';
+                } else {
+                    currentAddress = null;
+                    notConnected.style.display = 'block';
+                    connected.style.display = 'none';
+                }
+            }
+        );
+    }
+
+    // Load pins
+    async function loadPins() {
+        loading.style.display = 'block';
+        error.style.display = 'none';
+        pinsTable.style.display = 'none';
+        empty.style.display = 'none';
+
+        try {
+            const resp = await fetch(`${pinningService}/local-pins`);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+
+            const data = await resp.json();
+            const pins = data.pins || [];
+
+            loading.style.display = 'none';
+
+            if (pins.length === 0) {
+                empty.style.display = 'block';
+                return;
+            }
+
+            pinsList.innerHTML = '';
+            pins.forEach(pin => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>
+                        <a href="${gateway}/${pin.cid}" target="_blank" class="font-monospace small">
+                            ${pin.cid.slice(0, 12)}...${pin.cid.slice(-6)}
+                        </a>
+                    </td>
+                    <td>
+                        <button class="btn btn-outline-danger btn-sm unpin-btn" data-cid="${pin.cid}">
+                            Unpin
+                        </button>
+                    </td>
+                `;
+                pinsList.appendChild(tr);
+            });
+
+            pinsTable.style.display = 'table';
+
+            // Add unpin handlers
+            document.querySelectorAll('.unpin-btn').forEach(btn => {
+                btn.addEventListener('click', () => unpinCid(btn.dataset.cid, btn));
+            });
+
+        } catch (e) {
+            loading.style.display = 'none';
+            error.textContent = `Failed to load pins: ${e.message}`;
+            error.style.display = 'block';
+        }
+    }
+
+    // Unpin
+    async function unpinCid(cid, btn) {
+        if (!currentAddress) {
+            alert('Connect wallet first');
+            return;
+        }
+
+        if (!confirm(`Unpin ${cid.slice(0, 12)}...?`)) return;
+
+        btn.disabled = true;
+        btn.textContent = 'Unpinning...';
+
+        try {
+            // Get timestamp and sign
+            let timestamp;
+            try {
+                const timeResp = await fetch(`${pinningService}/time`);
+                const timeData = await timeResp.json();
+                timestamp = timeData.time ?? timeData.timestamp ?? Date.now();
+            } catch {
+                timestamp = Date.now();
+            }
+
+            const message = `Authorize Blue Railroad pinning\nTimestamp: ${timestamp}`;
+            const signature = await signMessage(wagmiConfig, { message });
+
+            const resp = await fetch(`${pinningService}/unpin/${cid}`, {
+                method: 'DELETE',
+                headers: {
+                    'X-Signature': signature,
+                    'X-Timestamp': timestamp.toString()
+                }
+            });
+
+            if (!resp.ok) {
+                const data = await resp.json().catch(() => ({}));
+                throw new Error(data.detail || `HTTP ${resp.status}`);
+            }
+
+            // Remove row
+            btn.closest('tr').remove();
+
+            // Check if empty
+            if (pinsList.children.length === 0) {
+                pinsTable.style.display = 'none';
+                empty.style.display = 'block';
+            }
+
+        } catch (e) {
+            alert(`Unpin failed: ${e.message}`);
+            btn.disabled = false;
+            btn.textContent = 'Unpin';
+        }
+    }
+
+    refreshBtn.addEventListener('click', loadPins);
+
+    // Initial load
+    loadPins();
+</script>
+{% endblock %}

--- a/src/sites/cryptograss.live/templates/pages/tools/upload-album.njk
+++ b/src/sites/cryptograss.live/templates/pages/tools/upload-album.njk
@@ -387,7 +387,7 @@ w3m-modal {
     document.addEventListener('DOMContentLoaded', function() {
         if (window.initUploadAlbumPage) {
             window.initUploadAlbumPage({
-                pinningService: 'https://justin2.hunter.cryptograss.live',
+                pinningService: 'https://delivery-kid.cryptograss.live',
                 gateway: 'https://ipfs.delivery-kid.cryptograss.live/ipfs'
             });
         } else {

--- a/src/sites/cryptograss.live/templates/pages/tools/upload-album.njk
+++ b/src/sites/cryptograss.live/templates/pages/tools/upload-album.njk
@@ -117,7 +117,7 @@
                     <div class="card semi-transparent-bg mb-4">
                         <div class="card-body">
                             <h5 class="card-title">Track Listing</h5>
-                            <p class="small text-muted mb-2">Click track titles to edit. Drag rows to reorder.</p>
+                            <p class="small text-muted mb-2">Click track titles to edit. Click ▶ to add metadata tags. Drag rows to reorder.</p>
 
                             <div id="draft-info" class="small text-muted mb-2" style="display: none;">
                                 Draft ID: <code id="draft-id-display"></code>
@@ -387,7 +387,7 @@ w3m-modal {
     document.addEventListener('DOMContentLoaded', function() {
         if (window.initUploadAlbumPage) {
             window.initUploadAlbumPage({
-                pinningService: 'https://delivery-kid.cryptograss.live',
+                pinningService: 'https://justin2.hunter.cryptograss.live',
                 gateway: 'https://ipfs.delivery-kid.cryptograss.live/ipfs'
             });
         } else {

--- a/src/sites/cryptograss.live/templates/pages/tools/upload-album.njk
+++ b/src/sites/cryptograss.live/templates/pages/tools/upload-album.njk
@@ -7,106 +7,168 @@
         <h1 class="text-center pixel-font">Album Upload</h1>
         <p class="text-center text-muted">Upload and pin audio albums to IPFS</p>
 
+        <!-- Step Indicator -->
+        <div class="step-indicator mb-4">
+            <div class="step-track">
+                <div class="step active" data-step="1">
+                    <div class="step-number">1</div>
+                    <div class="step-label">Connect</div>
+                </div>
+                <div class="step-connector"></div>
+                <div class="step" data-step="2">
+                    <div class="step-number">2</div>
+                    <div class="step-label">Upload</div>
+                </div>
+                <div class="step-connector"></div>
+                <div class="step" data-step="3">
+                    <div class="step-number">3</div>
+                    <div class="step-label">Review</div>
+                </div>
+                <div class="step-connector"></div>
+                <div class="step" data-step="4">
+                    <div class="step-number">4</div>
+                    <div class="step-label">Finalize</div>
+                </div>
+            </div>
+        </div>
+
         <div class="row mt-4">
             <div class="col-md-10 offset-md-1">
-                <!-- Wallet Connection -->
-                <div class="card semi-transparent-bg mb-4">
-                    <div class="card-body">
-                        <h5 class="card-title">1. Connect Wallet</h5>
-                        <p class="small text-muted mb-2">
-                            Connect your wallet to authorize uploads. Only wallets on the allowlist can pin files.
-                        </p>
-                        <div id="wallet-status">
-                            <p id="not-connected-msg">Not connected</p>
-                            <p id="connected-address" style="display: none;" class="font-monospace"></p>
-                            <p id="authorization-status" style="display: none;" class="small mt-2"></p>
-                        </div>
-                        <button id="connect-wallet-btn" class="btn btn-primary">Connect Wallet</button>
-                    </div>
-                </div>
 
-                <!-- Album Metadata -->
-                <div class="card semi-transparent-bg mb-4">
-                    <div class="card-body">
-                        <h5 class="card-title">2. Album Info</h5>
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="album-title" class="form-label">Album Title</label>
-                                <input type="text" class="form-control" id="album-title" placeholder="e.g. 4masks">
+                <!-- Step 1: Wallet Connection -->
+                <div id="step-1-wallet" class="upload-step">
+                    <div class="card semi-transparent-bg mb-4">
+                        <div class="card-body">
+                            <h5 class="card-title">Connect Wallet</h5>
+                            <p class="small text-muted mb-2">
+                                Connect your wallet to authorize uploads. Only wallets on the allowlist can pin files.
+                            </p>
+                            <div id="wallet-status">
+                                <p id="not-connected-msg">Not connected</p>
+                                <p id="connected-address" style="display: none;" class="font-monospace"></p>
+                                <p id="authorization-status" style="display: none;" class="small mt-2"></p>
                             </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="album-artist" class="form-label">Artist</label>
-                                <input type="text" class="form-control" id="album-artist" placeholder="e.g. Justin Holmes">
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="album-version" class="form-label">Version</label>
-                                <input type="text" class="form-control" id="album-version" placeholder="e.g. RC0, master">
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="album-year" class="form-label">Year</label>
-                                <input type="text" class="form-control" id="album-year" placeholder="e.g. 2024">
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="album-description" class="form-label">Description (optional)</label>
-                            <textarea class="form-control" id="album-description" rows="2" placeholder="Notes about this release..."></textarea>
+                            <button id="connect-wallet-btn" class="btn btn-primary">Connect Wallet</button>
                         </div>
                     </div>
                 </div>
 
-                <!-- File Upload -->
-                <div class="card semi-transparent-bg mb-4">
-                    <div class="card-body">
-                        <h5 class="card-title">3. Upload Tracks</h5>
-                        <p class="small text-muted mb-2">
-                            Select audio files (FLAC, WAV, MP3, OGG). Files will be transcoded to OGG for streaming.
-                        </p>
+                <!-- Step 2: File Upload -->
+                <div id="step-2-upload" class="upload-step" style="display: none;">
+                    <div class="card semi-transparent-bg mb-4">
+                        <div class="card-body">
+                            <h5 class="card-title">Upload Audio Files</h5>
+                            <p class="small text-muted mb-2">
+                                Select audio files (FLAC, WAV, MP3, OGG). Files will be analyzed and you can edit metadata in the next step.
+                            </p>
 
-                        <div id="upload-area" class="upload-dropzone mb-3">
-                            <input type="file" id="file-input" style="display: none;" multiple accept=".flac,.wav,.mp3,.ogg,.m4a">
-                            <div id="dropzone-content">
-                                <div class="dropzone-icon">🎵</div>
-                                <p class="mb-0">Drop audio files here or <a href="#" id="browse-link">browse</a></p>
-                                <p class="small text-muted mb-0">Supports FLAC, WAV, MP3, OGG, M4A</p>
+                            <div id="upload-area" class="upload-dropzone mb-3">
+                                <input type="file" id="file-input" style="display: none;" multiple accept=".flac,.wav,.mp3,.ogg,.m4a,.jpg,.jpeg,.png,.webp">
+                                <div id="dropzone-content">
+                                    <div class="dropzone-icon">🎵</div>
+                                    <p class="mb-0">Drop audio files here or <a href="#" id="browse-link">browse</a></p>
+                                    <p class="small text-muted mb-0">Supports FLAC, WAV, MP3, OGG, M4A + cover art</p>
+                                </div>
+                            </div>
+
+                            <div id="upload-progress" style="display: none;" class="mb-3">
+                                <div class="d-flex align-items-center mb-2">
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span class="ms-2" id="upload-progress-text">Uploading and analyzing files...</span>
+                                </div>
+                                <div class="progress" style="height: 6px;">
+                                    <div id="upload-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%"></div>
+                                </div>
+                            </div>
+
+                            <div id="upload-error" class="alert alert-danger" style="display: none;"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Step 3: Review & Edit -->
+                <div id="step-3-review" class="upload-step" style="display: none;">
+                    <div class="card semi-transparent-bg mb-4">
+                        <div class="card-body">
+                            <h5 class="card-title">Album Info</h5>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="album-title" class="form-label">Album Title <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control" id="album-title" placeholder="e.g. 4masks">
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label for="album-artist" class="form-label">Artist <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control" id="album-artist" placeholder="e.g. Justin Holmes">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="album-year" class="form-label">Year</label>
+                                    <input type="text" class="form-control" id="album-year" placeholder="e.g. 2024">
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label for="album-description" class="form-label">Description</label>
+                                    <input type="text" class="form-control" id="album-description" placeholder="Notes about this release...">
+                                </div>
                             </div>
                         </div>
+                    </div>
 
-                        <!-- Track List -->
-                        <div id="track-list-section" style="display: none;">
-                            <h6 class="mb-2">Track Listing</h6>
-                            <p class="small text-muted">Click track titles to edit. Drag to reorder.</p>
+                    <div class="card semi-transparent-bg mb-4">
+                        <div class="card-body">
+                            <h5 class="card-title">Track Listing</h5>
+                            <p class="small text-muted mb-2">Click track titles to edit. Drag rows to reorder.</p>
+
+                            <div id="draft-info" class="small text-muted mb-2" style="display: none;">
+                                Draft ID: <code id="draft-id-display"></code>
+                                <span class="ms-2">Expires: <span id="draft-expires-display"></span></span>
+                            </div>
+
                             <table class="table table-sm" id="track-table">
                                 <thead>
                                     <tr>
                                         <th style="width: 40px;">#</th>
                                         <th>Title</th>
-                                        <th style="width: 120px;">File</th>
+                                        <th style="width: 100px;">Format</th>
+                                        <th style="width: 80px;">Duration</th>
                                         <th style="width: 80px;">Size</th>
                                     </tr>
                                 </thead>
                                 <tbody id="track-list">
                                 </tbody>
                             </table>
-                        </div>
 
-                        <div id="upload-progress" style="display: none;" class="mb-3">
-                            <div class="d-flex align-items-center mb-2">
-                                <span class="spinner-border spinner-border-sm" role="status"></span>
-                                <span class="ms-2" id="upload-progress-text">Uploading...</span>
+                            <div class="d-flex justify-content-between align-items-center mt-3">
+                                <button id="back-to-upload-btn" class="btn btn-outline-secondary btn-sm">
+                                    ← Add More Files
+                                </button>
+                                <button id="finalize-btn" class="btn btn-success" disabled>
+                                    Finalize Album
+                                </button>
                             </div>
-                            <div class="progress" style="height: 6px;">
-                                <div id="upload-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%"></div>
-                            </div>
-                            <div id="progress-details" class="small text-muted mt-1"></div>
                         </div>
+                    </div>
+                </div>
 
-                        <div id="upload-error" class="alert alert-danger" style="display: none;"></div>
+                <!-- Step 4: Finalize -->
+                <div id="step-4-finalize" class="upload-step" style="display: none;">
+                    <div class="card semi-transparent-bg mb-4">
+                        <div class="card-body">
+                            <h5 class="card-title">Processing Album</h5>
 
-                        <button id="upload-btn" class="btn btn-success" disabled>
-                            Upload Album
-                        </button>
+                            <div id="finalize-progress" class="mb-3">
+                                <div class="d-flex align-items-center mb-2">
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span class="ms-2" id="finalize-progress-text">Preparing...</span>
+                                </div>
+                                <div class="progress" style="height: 6px;">
+                                    <div id="finalize-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%"></div>
+                                </div>
+                                <div id="finalize-details" class="small text-muted mt-1"></div>
+                            </div>
+
+                            <div id="finalize-error" class="alert alert-danger" style="display: none;"></div>
+                        </div>
                     </div>
                 </div>
 
@@ -128,6 +190,16 @@
                         <div class="mb-3">
                             <label class="form-label small text-muted">Gateway URL</label>
                             <a id="gateway-link" href="#" target="_blank" class="d-block font-monospace small"></a>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label small text-muted">Album Structure</label>
+                            <div class="font-monospace small bg-dark p-2 rounded">
+                                <div>📁 album/</div>
+                                <div class="ms-3">📁 flac/ (original files)</div>
+                                <div class="ms-3">📁 ogg/ (transcoded for streaming)</div>
+                                <div class="ms-3">📄 metadata.json</div>
+                            </div>
                         </div>
 
                         <div id="result-tracks" class="mb-3">
@@ -165,6 +237,75 @@ w3m-modal {
     z-index: 10000 !important;
 }
 
+/* Step Indicator */
+.step-indicator {
+    padding: 0 20px;
+}
+
+.step-track {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+
+.step.active, .step.completed {
+    opacity: 1;
+}
+
+.step-number {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #333;
+    border: 2px solid #666;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    margin-bottom: 4px;
+    transition: all 0.2s;
+}
+
+.step.active .step-number {
+    background: #4a7c59;
+    border-color: #4a7c59;
+}
+
+.step.completed .step-number {
+    background: #198754;
+    border-color: #198754;
+}
+
+.step.completed .step-number::after {
+    content: "✓";
+}
+
+.step-label {
+    font-size: 12px;
+    color: #999;
+}
+
+.step.active .step-label {
+    color: #fff;
+}
+
+.step-connector {
+    width: 40px;
+    height: 2px;
+    background: #444;
+    margin: 0 8px;
+    margin-bottom: 20px;
+}
+
+/* Upload Dropzone */
 .upload-dropzone {
     border: 2px dashed #ccc;
     border-radius: 8px;
@@ -199,6 +340,7 @@ w3m-modal {
     color: #dc3545;
 }
 
+/* Track Table */
 #track-table tbody tr {
     cursor: move;
 }
@@ -207,6 +349,8 @@ w3m-modal {
     cursor: text;
     padding: 2px 4px;
     border-radius: 3px;
+    min-width: 100px;
+    display: inline-block;
 }
 
 #track-table .track-title:hover {
@@ -216,6 +360,7 @@ w3m-modal {
 #track-table .track-title:focus {
     background: white;
     outline: 2px solid #4a7c59;
+    color: #333;
 }
 
 .dragging {
@@ -225,6 +370,16 @@ w3m-modal {
 #result-track-list .list-group-item {
     background: transparent;
     border-color: rgba(255,255,255,0.1);
+}
+
+/* Responsive */
+@media (max-width: 576px) {
+    .step-connector {
+        width: 20px;
+    }
+    .step-label {
+        font-size: 10px;
+    }
 }
 </style>
 


### PR DESCRIPTION
## Summary

Replaces single-step upload+transcode+pin with a multi-step workflow:

1. **Connect wallet** - Authorization step
2. **Upload files** - Server creates draft, analyzes audio metadata
3. **Review & edit** - Edit track titles, reorder with drag-and-drop, enter album info
4. **Finalize** - Transcode + pin with SSE progress streaming

## Features

- **Visual step indicator** showing progress through the 4-step workflow
- **Inline track title editing** - click to edit, Enter to save
- **Drag-and-drop track reordering** 
- **Page refresh recovery** - localStorage + server state ensures work isn't lost
- **Draft info display** - shows draft ID and expiration time
- **Dual format result** - shows both FLAC and OGG directories in final album

## UI Changes

- Step indicator at top with numbered steps and progress highlighting
- Separate cards for each step (only current step visible)
- Review step shows analyzed track metadata (format, duration, size)
- Finalize step shows real-time progress with SSE events
- Result section shows album structure diagram

## Backend Dependency

Requires the new `/draft-album` endpoints in delivery-kid pinning service:
- cryptograss/maybelle-config#68

## Test plan

- [ ] Connect wallet → advances to upload step
- [ ] Drop files → uploads, shows review with analyzed metadata
- [ ] Edit track title → inline editing works
- [ ] Drag track → reorders, updates numbering
- [ ] Refresh page → draft recovered from localStorage + server
- [ ] Click Finalize → shows progress, completes with CID
- [ ] Upload another → resets state for new upload